### PR TITLE
Add an option to disable the spec-sync controller

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -238,7 +238,7 @@ kind-bootstrap-cluster-dev: kind-create-cluster install-crds install-resources
 .PHONY: kind-deploy-controller
 kind-deploy-controller:
 	@echo installing $(IMG)
-	kubectl create ns $(KIND_NAMESPACE) --kubeconfig=$(MANAGED_CONFIG)
+	-kubectl create ns $(KIND_NAMESPACE) --kubeconfig=$(MANAGED_CONFIG)
 	kubectl create secret -n $(KIND_NAMESPACE) generic hub-kubeconfig --from-file=kubeconfig=$(HUB_CONFIG_INTERNAL) --kubeconfig=$(MANAGED_CONFIG)
 	kubectl apply -f deploy/operator.yaml -n $(KIND_NAMESPACE) --kubeconfig=$(MANAGED_CONFIG)
 
@@ -276,9 +276,9 @@ install-crds:
 .PHONY: install-resources
 install-resources:
 	@echo creating namespace on hub
-	kubectl create ns $(MANAGED_CLUSTER_NAME) --kubeconfig=$(HUB_CONFIG)
+	-kubectl create ns $(MANAGED_CLUSTER_NAME) --kubeconfig=$(HUB_CONFIG)
 	@echo creating namespace on managed
-	kubectl create ns $(MANAGED_CLUSTER_NAME) --kubeconfig=$(MANAGED_CONFIG)
+	-kubectl create ns $(MANAGED_CLUSTER_NAME) --kubeconfig=$(MANAGED_CONFIG)
 
 .PHONY: e2e-dependencies
 e2e-dependencies:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The template sync controller runs on managed clusters and updates objects define
 
 This controller watches for changes on `Policies` in the cluster namespace on the managed cluster to trigger a reconcile. On each reconcile, it creates/updates/deletes objects defined in the `spec.policy-templates` of those `Policies`.
 
-## Geting started
+## Getting started
 
 Go to the
 [Contributing guide](https://github.com/open-cluster-management-io/community/blob/main/sig-policy/contribution-guidelines.md)

--- a/tool/options.go
+++ b/tool/options.go
@@ -15,6 +15,7 @@ type SyncerOptions struct {
 	ClusterNamespaceOnHub     string
 	HubConfigFilePathName     string
 	ManagedConfigFilePathName string
+	DisableSpecSync           bool
 	EnableLease               bool
 	EnableLeaderElection      bool
 	LegacyLeaderElection      bool
@@ -64,6 +65,13 @@ func ProcessFlags() {
 		"enable-lease",
 		false,
 		"If enabled, the controller will start the lease controller to report its status",
+	)
+
+	flag.BoolVar(
+		&Options.DisableSpecSync,
+		"disable-spec-sync",
+		false,
+		"If enabled, the spec-sync controller will not be started. This is used when running on the Hub.",
 	)
 
 	flag.BoolVar(


### PR DESCRIPTION
When running on the Hub, spec-sync controller should be disabled since the replicated policies are already present on the Hub from the Policy Propagator.

Relates:
https://github.com/stolostron/backlog/issues/25999 https://github.com/stolostron/backlog/issues/25949

Signed-off-by: mprahl <mprahl@users.noreply.github.com>