### PR TITLE
Handle when a policy doesn't have dependencies

### DIFF
--- a/controllers/templatesync/template_sync.go
+++ b/controllers/templatesync/template_sync.go
@@ -367,18 +367,25 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 		}
 	}
 
-	depsToWatch := make([]depclient.ObjectIdentifier, 0, len(allDeps))
-	for depID := range allDeps {
-		depsToWatch = append(depsToWatch, depID)
-	}
-
-	err = r.DynamicWatcher.AddOrUpdateWatcher(depclient.ObjectIdentifier{
+	policyObjectID := depclient.ObjectIdentifier{
 		Group:     instance.GroupVersionKind().Group,
 		Version:   instance.GroupVersionKind().Version,
 		Kind:      instance.GroupVersionKind().Kind,
 		Namespace: instance.Namespace,
 		Name:      instance.Name,
-	}, depsToWatch...)
+	}
+
+	if len(allDeps) != 0 {
+		depsToWatch := make([]depclient.ObjectIdentifier, 0, len(allDeps))
+		for depID := range allDeps {
+			depsToWatch = append(depsToWatch, depID)
+		}
+
+		err = r.DynamicWatcher.AddOrUpdateWatcher(policyObjectID, depsToWatch...)
+	} else {
+		err = r.DynamicWatcher.RemoveWatcher(policyObjectID)
+	}
+
 	if err != nil {
 		resultError = err
 		reqLogger.Error(resultError, "Error updating dependency watcher")


### PR DESCRIPTION
Without this, the dependencies never get cleaned up when they are entirely removed. Additionally, if the policy had no dependencies, it would error since that is invalid input to AddOrUpdateWatcher.

Signed-off-by: mprahl <mprahl@users.noreply.github.com>