### PR TITLE
Set pending state on policies if dependencies are not met + remove template

### DIFF
--- a/main.go
+++ b/main.go
@@ -362,11 +362,12 @@ func getManager(
 	}
 
 	templateReconciler := &templatesync.PolicyReconciler{
-		Client:         mgr.GetClient(),
-		DynamicWatcher: watcher,
-		Scheme:         mgr.GetScheme(),
-		Config:         mgr.GetConfig(),
-		Recorder:       mgr.GetEventRecorderFor(templatesync.ControllerName),
+		Client:           mgr.GetClient(),
+		DynamicWatcher:   watcher,
+		Scheme:           mgr.GetScheme(),
+		Config:           mgr.GetConfig(),
+		Recorder:         mgr.GetEventRecorderFor(templatesync.ControllerName),
+		ClusterNamespace: tool.Options.ClusterNamespace,
 	}
 
 	go func() {

--- a/test/e2e/case12_ordering_test.go
+++ b/test/e2e/case12_ordering_test.go
@@ -1,0 +1,452 @@
+// Copyright (c) 2020 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"open-cluster-management.io/governance-policy-propagator/test/utils"
+)
+
+const (
+	case12PolicyName          string = "case12-test-policy"
+	case12PolicyYaml          string = "../resources/case12_ordering/case12-plc.yaml"
+	case12ExtraDepsPolicyName string = "case12-test-policy-multi"
+	case12ExtraDepsPolicyYaml string = "../resources/case12_ordering/case12-plc-multiple-deps.yaml"
+	case12Plc2TemplatesName   string = "case12-test-policy-2-templates"
+	case12Plc2TemplatesYaml   string = "../resources/case12_ordering/case12-plc-2-template.yaml"
+	case12DepName             string = "namespace-foo-setup-policy"
+	case12DepYaml             string = "../resources/case12_ordering/case12-dependency.yaml"
+	case12DepBName            string = "namespace-foo-setup-policy-b"
+	case12DepBYaml            string = "../resources/case12_ordering/case12-dependency-b.yaml"
+)
+
+// Helper function to create events
+func generateEventOnPolicy(plcName string, cfgPlcNamespacedName string, eventType string, msg string) {
+	managedPlc := utils.GetWithTimeout(
+		clientManagedDynamic,
+		gvrPolicy,
+		plcName,
+		clusterNamespace,
+		true,
+		defaultTimeoutSeconds)
+	Expect(managedPlc).NotTo(BeNil())
+	managedRecorder.Event(
+		managedPlc,
+		eventType,
+		"policy: "+cfgPlcNamespacedName,
+		msg)
+}
+
+var _ = Describe("Test status sync", Ordered, func() {
+	AfterEach(func() {
+		opt := metav1.ListOptions{}
+		utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 0, true, defaultTimeoutSeconds)
+		utils.ListWithTimeout(clientManagedDynamic, gvrPolicy, opt, 0, true, defaultTimeoutSeconds)
+	})
+	It("Should set to compliant when dep status is compliant", func() {
+		By("Creating a dep on hub cluster in ns:" + clusterNamespaceOnHub)
+		_, err := kubectlHub("apply", "-f", case12DepYaml, "-n", clusterNamespaceOnHub)
+		Expect(err).To(BeNil())
+		hubPlc := utils.GetWithTimeout(
+			clientHubDynamic,
+			gvrPolicy,
+			case12DepName,
+			clusterNamespaceOnHub,
+			true,
+			defaultTimeoutSeconds)
+		Expect(hubPlc).NotTo(BeNil())
+
+		By("Creating a policy on hub cluster in ns:" + clusterNamespaceOnHub)
+		_, err = kubectlHub("apply", "-f", case12PolicyYaml, "-n", clusterNamespaceOnHub)
+		Expect(err).To(BeNil())
+		hubPlc = utils.GetWithTimeout(
+			clientHubDynamic,
+			gvrPolicy,
+			case12PolicyName,
+			clusterNamespaceOnHub,
+			true,
+			defaultTimeoutSeconds)
+		Expect(hubPlc).NotTo(BeNil())
+
+		By("Generating a compliant event on the dependency")
+		generateEventOnPolicy(
+			case12DepName,
+			"managed/namespace-foo-setup-configpolicy",
+			"Normal",
+			"Compliant; No violation detected",
+		)
+
+		By("Checking if dependency status is compliant")
+		Eventually(checkCompliance(case12DepName), defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
+
+		By("Generating a compliant event on the policy")
+		generateEventOnPolicy(
+			case12PolicyName,
+			"managed/case12-config-policy",
+			"Normal",
+			"Compliant; No violation detected",
+		)
+
+		By("Checking if policy status is compliant")
+		Eventually(checkCompliance(case12PolicyName), defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
+
+		By("Deleting dependency on hub cluster in ns:" + clusterNamespaceOnHub)
+		_, err = kubectlHub("delete", "-f", case12DepYaml, "-n", clusterNamespaceOnHub)
+		Expect(err).To(BeNil())
+
+		By("Deleting the policy on hub cluster in ns:" + clusterNamespaceOnHub)
+		_, err = kubectlHub("delete", "-f", case12PolicyYaml, "-n", clusterNamespaceOnHub)
+		Expect(err).To(BeNil())
+	})
+	It("Should set to Pending when dep status is NonCompliant", func() {
+		By("Creating a dep on hub cluster in ns:" + clusterNamespaceOnHub)
+		_, err := kubectlHub("apply", "-f", case12DepYaml, "-n", clusterNamespaceOnHub)
+		Expect(err).To(BeNil())
+		hubPlc := utils.GetWithTimeout(
+			clientHubDynamic,
+			gvrPolicy,
+			case12DepName,
+			clusterNamespaceOnHub,
+			true,
+			defaultTimeoutSeconds)
+		Expect(hubPlc).NotTo(BeNil())
+
+		By("Creating a policy on hub cluster in ns:" + clusterNamespaceOnHub)
+		_, err = kubectlHub("apply", "-f", case12PolicyYaml, "-n", clusterNamespaceOnHub)
+		Expect(err).To(BeNil())
+		hubPlc = utils.GetWithTimeout(
+			clientHubDynamic,
+			gvrPolicy,
+			case12PolicyName,
+			clusterNamespaceOnHub,
+			true,
+			defaultTimeoutSeconds)
+		Expect(hubPlc).NotTo(BeNil())
+		By("Generating a noncompliant event on the policy")
+		generateEventOnPolicy(
+			case12DepName,
+			"managed/namespace-foo-setup-configpolicy",
+			"Warning",
+			"NonCompliant; there is violation",
+		)
+
+		By("Checking if dependency status is noncompliant")
+		Eventually(checkCompliance(case12DepName), defaultTimeoutSeconds, 1).Should(Equal("NonCompliant"))
+
+		By("Checking if policy status is pending")
+		Eventually(checkCompliance(case12PolicyName), defaultTimeoutSeconds, 1).Should(Equal("Pending"))
+
+		By("Deleting dependency on hub cluster in ns:" + clusterNamespaceOnHub)
+		_, err = kubectlHub("delete", "-f", case12DepYaml, "-n", clusterNamespaceOnHub)
+		Expect(err).To(BeNil())
+
+		By("Deleting the policy on hub cluster in ns:" + clusterNamespaceOnHub)
+		_, err = kubectlHub("delete", "-f", case12PolicyYaml, "-n", clusterNamespaceOnHub)
+		Expect(err).To(BeNil())
+	})
+	It("Should set to Compliant when dep status is resolved", func() {
+		By("Creating a dep on hub cluster in ns:" + clusterNamespaceOnHub)
+		_, err := kubectlHub("apply", "-f", case12DepYaml, "-n", clusterNamespaceOnHub)
+		Expect(err).To(BeNil())
+		hubPlc := utils.GetWithTimeout(
+			clientHubDynamic,
+			gvrPolicy,
+			case12DepName,
+			clusterNamespaceOnHub,
+			true,
+			defaultTimeoutSeconds)
+		Expect(hubPlc).NotTo(BeNil())
+
+		By("Creating a policy on hub cluster in ns:" + clusterNamespaceOnHub)
+		_, err = kubectlHub("apply", "-f", case12PolicyYaml, "-n", clusterNamespaceOnHub)
+		Expect(err).To(BeNil())
+		hubPlc = utils.GetWithTimeout(
+			clientHubDynamic,
+			gvrPolicy,
+			case12PolicyName,
+			clusterNamespaceOnHub,
+			true,
+			defaultTimeoutSeconds)
+		Expect(hubPlc).NotTo(BeNil())
+		By("Generating a non compliant event on the dep")
+		generateEventOnPolicy(
+			case12DepName,
+			"managed/namespace-foo-setup-configpolicy",
+			"Warning",
+			"NonCompliant; there is violation",
+		)
+
+		By("Checking if dependency status is noncompliant")
+		Eventually(checkCompliance(case12DepName), defaultTimeoutSeconds, 1).Should(Equal("NonCompliant"))
+
+		By("Checking if policy status is pending")
+		Eventually(checkCompliance(case12PolicyName), defaultTimeoutSeconds, 1).Should(Equal("Pending"))
+
+		By("Generating a compliant event on the dependency")
+		generateEventOnPolicy(
+			case12DepName,
+			"managed/namespace-foo-setup-configpolicy",
+			"Normal",
+			"Compliant; No violation detected",
+		)
+
+		By("Checking if dependency status is compliant")
+		Eventually(checkCompliance(case12DepName), defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
+
+		By("Generating a compliant event on the policy")
+		generateEventOnPolicy(
+			case12PolicyName,
+			"managed/case12-config-policy",
+			"Normal",
+			"Compliant; No violation detected",
+		)
+
+		By("Checking if policy status is compliant")
+		Eventually(checkCompliance(case12PolicyName), defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
+
+		By("Deleting dependency on hub cluster in ns:" + clusterNamespaceOnHub)
+		_, err = kubectlHub("delete", "-f", case12DepYaml, "-n", clusterNamespaceOnHub)
+		Expect(err).To(BeNil())
+
+		By("Deleting the policy on hub cluster in ns:" + clusterNamespaceOnHub)
+		_, err = kubectlHub("delete", "-f", case12PolicyYaml, "-n", clusterNamespaceOnHub)
+		Expect(err).To(BeNil())
+	})
+	It("Should remove template if dependency changes", func() {
+		By("Creating a dep on hub cluster in ns:" + clusterNamespaceOnHub)
+		_, err := kubectlHub("apply", "-f", case12DepYaml, "-n", clusterNamespaceOnHub)
+		Expect(err).To(BeNil())
+		hubPlc := utils.GetWithTimeout(
+			clientHubDynamic,
+			gvrPolicy,
+			case12DepName,
+			clusterNamespaceOnHub,
+			true,
+			defaultTimeoutSeconds)
+		Expect(hubPlc).NotTo(BeNil())
+
+		By("Creating a policy on hub cluster in ns:" + clusterNamespaceOnHub)
+		_, err = kubectlHub("apply", "-f", case12PolicyYaml, "-n", clusterNamespaceOnHub)
+		Expect(err).To(BeNil())
+		hubPlc = utils.GetWithTimeout(
+			clientHubDynamic,
+			gvrPolicy,
+			case12PolicyName,
+			clusterNamespaceOnHub,
+			true,
+			defaultTimeoutSeconds)
+		Expect(hubPlc).NotTo(BeNil())
+
+		By("Generating a compliant event on the dependency")
+		generateEventOnPolicy(
+			case12DepName,
+			"managed/namespace-foo-setup-configpolicy",
+			"Normal",
+			"Compliant; No violation detected",
+		)
+
+		By("Checking if dependency status is compliant")
+		Eventually(checkCompliance(case12DepName), defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
+
+		By("Generating a compliant event on the policy")
+		generateEventOnPolicy(
+			case12PolicyName,
+			"managed/case12-config-policy",
+			"Normal",
+			"Compliant; No violation detected",
+		)
+
+		By("Checking if policy status is compliant")
+		Eventually(checkCompliance(case12PolicyName), defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
+
+		By("Generating a non compliant event on the dep")
+		generateEventOnPolicy(
+			case12DepName,
+			"managed/namespace-foo-setup-configpolicy",
+			"Warning",
+			"NonCompliant; there is violation",
+		)
+
+		By("Checking if dependency status is noncompliant")
+		Eventually(checkCompliance(case12DepName), defaultTimeoutSeconds, 1).Should(Equal("NonCompliant"))
+
+		By("Checking if policy status is pending")
+		Eventually(checkCompliance(case12PolicyName), defaultTimeoutSeconds, 1).Should(Equal("Pending"))
+
+		By("Deleting dependency on hub cluster in ns:" + clusterNamespaceOnHub)
+		_, err = kubectlHub("delete", "-f", case12DepYaml, "-n", clusterNamespaceOnHub)
+		Expect(err).To(BeNil())
+
+		By("Deleting the policy on hub cluster in ns:" + clusterNamespaceOnHub)
+		_, err = kubectlHub("delete", "-f", case12PolicyYaml, "-n", clusterNamespaceOnHub)
+		Expect(err).To(BeNil())
+	})
+	It("Should process extra dependencies properly", func() {
+		By("Creating a policy on hub cluster in ns:" + clusterNamespaceOnHub)
+		_, err := kubectlHub("apply", "-f", case12ExtraDepsPolicyYaml, "-n", clusterNamespaceOnHub)
+		Expect(err).To(BeNil())
+		hubPlc := utils.GetWithTimeout(
+			clientHubDynamic,
+			gvrPolicy,
+			case12ExtraDepsPolicyName,
+			clusterNamespaceOnHub,
+			true,
+			defaultTimeoutSeconds)
+		Expect(hubPlc).NotTo(BeNil())
+
+		By("Creating a dep on hub cluster in ns:" + clusterNamespaceOnHub)
+		_, err = kubectlHub("apply", "-f", case12DepYaml, "-n", clusterNamespaceOnHub)
+		Expect(err).To(BeNil())
+		hubPlc = utils.GetWithTimeout(
+			clientHubDynamic,
+			gvrPolicy,
+			case12DepName,
+			clusterNamespaceOnHub,
+			true,
+			defaultTimeoutSeconds)
+		Expect(hubPlc).NotTo(BeNil())
+
+		By("Creating an extra dep on hub cluster in ns:" + clusterNamespaceOnHub)
+		_, err = kubectlHub("apply", "-f", case12DepBYaml, "-n", clusterNamespaceOnHub)
+		Expect(err).To(BeNil())
+		hubPlc = utils.GetWithTimeout(
+			clientHubDynamic,
+			gvrPolicy,
+			case12DepBName,
+			clusterNamespaceOnHub,
+			true,
+			defaultTimeoutSeconds)
+		Expect(hubPlc).NotTo(BeNil())
+
+		By("Generating a non compliant event on the dep b")
+		generateEventOnPolicy(
+			case12DepBName,
+			"managed/namespace-foo-setup-configpolicy-b",
+			"Warning",
+			"NonCompliant; there is violation",
+		)
+
+		By("Checking if dependency status is noncompliant")
+		Eventually(checkCompliance(case12DepBName), defaultTimeoutSeconds, 1).Should(Equal("NonCompliant"))
+
+		By("Generating a compliant event on the dependency")
+		generateEventOnPolicy(
+			case12DepName,
+			"managed/namespace-foo-setup-configpolicy",
+			"Normal",
+			"Compliant; No violation detected",
+		)
+
+		By("Checking if dependency status is compliant")
+		Eventually(checkCompliance(case12DepName), defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
+
+		By("Generating a compliant event on the policy")
+		generateEventOnPolicy(
+			case12ExtraDepsPolicyName,
+			"managed/case12-config-policy-multi",
+			"Normal",
+			"Compliant; No violation detected",
+		)
+
+		By("Checking if policy status is pending")
+		Eventually(checkCompliance(case12ExtraDepsPolicyName), defaultTimeoutSeconds, 1).Should(Equal("Pending"))
+
+		By("Deleting the policy on hub cluster in ns:" + clusterNamespaceOnHub)
+		_, err = kubectlHub("delete", "-f", case12ExtraDepsPolicyYaml, "-n", clusterNamespaceOnHub)
+		Expect(err).To(BeNil())
+
+		By("Deleting dependency on hub cluster in ns:" + clusterNamespaceOnHub)
+		_, err = kubectlHub("delete", "-f", case12DepYaml, "-n", clusterNamespaceOnHub)
+		Expect(err).To(BeNil())
+
+		By("Deleting dependency b on hub cluster in ns:" + clusterNamespaceOnHub)
+		_, err = kubectlHub("delete", "-f", case12DepBYaml, "-n", clusterNamespaceOnHub)
+		Expect(err).To(BeNil())
+	})
+	It("Should handle policies with multiple templates (with different dependencies) properly", func() {
+		By("Creating a policy on hub cluster in ns:" + clusterNamespaceOnHub)
+		_, err := kubectlHub("apply", "-f", case12Plc2TemplatesYaml, "-n", clusterNamespaceOnHub)
+		Expect(err).To(BeNil())
+		hubPlc := utils.GetWithTimeout(
+			clientHubDynamic,
+			gvrPolicy,
+			case12Plc2TemplatesName,
+			clusterNamespaceOnHub,
+			true,
+			defaultTimeoutSeconds)
+		Expect(hubPlc).NotTo(BeNil())
+
+		By("Creating a dep on hub cluster in ns:" + clusterNamespaceOnHub)
+		_, err = kubectlHub("apply", "-f", case12DepYaml, "-n", clusterNamespaceOnHub)
+		Expect(err).To(BeNil())
+		hubPlc = utils.GetWithTimeout(
+			clientHubDynamic,
+			gvrPolicy,
+			case12DepName,
+			clusterNamespaceOnHub,
+			true,
+			defaultTimeoutSeconds)
+		Expect(hubPlc).NotTo(BeNil())
+
+		By("Creating an extra dep on hub cluster in ns:" + clusterNamespaceOnHub)
+		_, err = kubectlHub("apply", "-f", case12DepBYaml, "-n", clusterNamespaceOnHub)
+		Expect(err).To(BeNil())
+		hubPlc = utils.GetWithTimeout(
+			clientHubDynamic,
+			gvrPolicy,
+			case12DepBName,
+			clusterNamespaceOnHub,
+			true,
+			defaultTimeoutSeconds)
+		Expect(hubPlc).NotTo(BeNil())
+
+		By("Generating a non compliant event on the dep a")
+		generateEventOnPolicy(
+			case12DepName,
+			"managed/namespace-foo-setup-configpolicy",
+			"Warning",
+			"NonCompliant; there is violation",
+		)
+
+		By("Checking if dependency status is noncompliant")
+		Eventually(checkCompliance(case12DepName), defaultTimeoutSeconds, 1).Should(Equal("NonCompliant"))
+
+		By("Generating a compliant event on the dependency b")
+		generateEventOnPolicy(
+			case12DepBName,
+			"managed/namespace-foo-setup-configpolicy-b",
+			"Normal",
+			"Compliant; No violation detected",
+		)
+
+		By("Checking if dependency status is compliant")
+		Eventually(checkCompliance(case12DepBName), defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
+
+		By("Generating a noncompliant event on the non-pending template")
+		generateEventOnPolicy(
+			case12Plc2TemplatesName,
+			"managed/case12-config-policy-2-templates-b",
+			"Warning",
+			"NonCompliant; there is violation",
+		)
+
+		// should be noncompliant - template A is pending and B is noncompliant
+		By("Checking if policy status is pending")
+		Eventually(checkCompliance(case12Plc2TemplatesName), defaultTimeoutSeconds, 1).Should(Equal("NonCompliant"))
+
+		By("Deleting the policy on hub cluster in ns:" + clusterNamespaceOnHub)
+		_, err = kubectlHub("delete", "-f", case12Plc2TemplatesYaml, "-n", clusterNamespaceOnHub)
+		Expect(err).To(BeNil())
+
+		By("Deleting dependency on hub cluster in ns:" + clusterNamespaceOnHub)
+		_, err = kubectlHub("delete", "-f", case12DepYaml, "-n", clusterNamespaceOnHub)
+		Expect(err).To(BeNil())
+
+		By("Deleting dependency b on hub cluster in ns:" + clusterNamespaceOnHub)
+		_, err = kubectlHub("delete", "-f", case12DepBYaml, "-n", clusterNamespaceOnHub)
+		Expect(err).To(BeNil())
+	})
+})

--- a/test/resources/case12_ordering/case12-dependency-b.yaml
+++ b/test/resources/case12_ordering/case12-dependency-b.yaml
@@ -1,0 +1,26 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: namespace-foo-setup-policy-b
+  labels:
+    policy.open-cluster-management.io/cluster-name: managed
+    policy.open-cluster-management.io/cluster-namespace: managed
+    policy.open-cluster-management.io/root-policy: namespace-foo-setup-policy-b
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: namespace-foo-setup-configpolicy-b
+        spec:
+          remediationAction: inform
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Namespace
+                metadata:
+                  name: policies

--- a/test/resources/case12_ordering/case12-dependency.yaml
+++ b/test/resources/case12_ordering/case12-dependency.yaml
@@ -1,0 +1,26 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: namespace-foo-setup-policy
+  labels:
+    policy.open-cluster-management.io/cluster-name: managed
+    policy.open-cluster-management.io/cluster-namespace: managed
+    policy.open-cluster-management.io/root-policy: namespace-foo-setup-policy
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: namespace-foo-setup-configpolicy
+        spec:
+          remediationAction: inform
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Namespace
+                metadata:
+                  name: policies

--- a/test/resources/case12_ordering/case12-plc-2-template.yaml
+++ b/test/resources/case12_ordering/case12-plc-2-template.yaml
@@ -1,0 +1,61 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: case12-test-policy-2-templates
+  labels:
+    policy.open-cluster-management.io/cluster-name: managed
+    policy.open-cluster-management.io/cluster-namespace: managed
+    policy.open-cluster-management.io/root-policy: case12-test-policy
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - extraDependencies:
+        - apiVersion: policy.open-cluster-management.io/v1
+          kind: Policy
+          name: namespace-foo-setup-policy
+          namespace: ""
+          compliance: Compliant
+      objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: case12-config-policy-2-templates-a
+        spec:
+          remediationAction: inform
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Pod
+                metadata:
+                  name: nginx-pod-e2e
+                  namespace: default
+                spec:
+                  containers:
+                    - name: nginx
+    - extraDependencies:
+        - apiVersion: policy.open-cluster-management.io/v1
+          kind: Policy
+          name: namespace-foo-setup-policy-b
+          namespace: ""
+          compliance: Compliant
+      objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: case12-config-policy-2-templates-b
+        spec:
+          remediationAction: inform
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Pod
+                metadata:
+                  name: nginx-pod-e2e
+                  namespace: default
+                spec:
+                  containers:
+                    - name: nginx
+

--- a/test/resources/case12_ordering/case12-plc-multiple-deps.yaml
+++ b/test/resources/case12_ordering/case12-plc-multiple-deps.yaml
@@ -1,0 +1,43 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: case12-test-policy-multi
+  labels:
+    policy.open-cluster-management.io/cluster-name: managed
+    policy.open-cluster-management.io/cluster-namespace: managed
+    policy.open-cluster-management.io/root-policy: case12-test-policy
+spec:
+  remediationAction: inform
+  disabled: false
+  dependencies:
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      name: namespace-foo-setup-policy
+      namespace: ""
+      compliance: Compliant
+  policy-templates:
+    - extraDependencies:
+        - apiVersion: policy.open-cluster-management.io/v1
+          kind: Policy
+          name: namespace-foo-setup-policy-b
+          namespace: ""
+          compliance: Compliant
+      objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: case12-config-policy-multi
+        spec:
+          remediationAction: inform
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Pod
+                metadata:
+                  name: nginx-pod-e2e
+                  namespace: default
+                spec:
+                  containers:
+                    - name: nginx
+

--- a/test/resources/case12_ordering/case12-plc.yaml
+++ b/test/resources/case12_ordering/case12-plc.yaml
@@ -1,0 +1,37 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: case12-test-policy
+  labels:
+    policy.open-cluster-management.io/cluster-name: managed
+    policy.open-cluster-management.io/cluster-namespace: managed
+    policy.open-cluster-management.io/root-policy: case12-test-policy
+spec:
+  remediationAction: inform
+  disabled: false
+  dependencies:
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      name: namespace-foo-setup-policy
+      namespace: ""
+      compliance: Compliant
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: case12-config-policy
+        spec:
+          remediationAction: inform
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Pod
+                metadata:
+                  name: nginx-pod-e2e
+                  namespace: default
+                spec:
+                  containers:
+                    - name: nginx
+


### PR DESCRIPTION
Adds logic to determine whether a policy template should be pending based on whether its dependencies are satisfied. If a template should be pending, these changes will remove it from the managed cluster and set the status of the parent policy to Pending.

https://github.com/stolostron/backlog/issues/26188
https://github.com/stolostron/backlog/issues/26189