### PR TITLE
Fix a bug where the /healthz endpoint pointed to underlying /readyz

### DIFF
--- a/main.go
+++ b/main.go
@@ -505,6 +505,8 @@ func startHealthProxy(ctx context.Context, wg *sync.WaitGroup, addresses ...stri
 	log := ctrl.Log.WithName("healthproxy")
 
 	for _, endpoint := range []string{"/healthz", "/readyz"} {
+		endpoint := endpoint
+
 		http.HandleFunc(endpoint, func(w http.ResponseWriter, r *http.Request) {
 			for _, address := range addresses {
 				req, err := http.NewRequestWithContext(

--- a/main.go
+++ b/main.go
@@ -528,9 +528,7 @@ func startHealthProxy(ctx context.Context, wg *sync.WaitGroup, addresses ...stri
 				defer resp.Body.Close()
 
 				if resp.StatusCode != http.StatusOK {
-					body := []byte{}
-
-					_, err = resp.Body.Read(body)
+					body, err := io.ReadAll(resp.Body)
 					if err != nil {
 						http.Error(w, "not ok", resp.StatusCode)
 


### PR DESCRIPTION
This bug caused the /healthz endpoint on the proxy to combine the controller
manager's /readyz endpoints. This would lead to the controller not
restarting when the Hub kubeconfig changed.

Relates:
https://issues.redhat.com/browse/ACM-1932