### PR TITLE
add kind to pending status

### DIFF
--- a/controllers/templatesync/template_sync.go
+++ b/controllers/templatesync/template_sync.go
@@ -379,7 +379,7 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 			errMsg := fmt.Sprintf("Dependencies were not satisfied: %s", pendingErr)
 
 			r.emitTemplatePending(instance, tIndex, tName, errMsg)
-			tLogger.Info("Dependencies were not satisfied in the policy template",
+			tLogger.Info("Dependencies were not satisfied for the policy template",
 				"namespace", instance.GetNamespace(),
 				"kind", gvk.Kind,
 			)
@@ -553,7 +553,7 @@ func (r *PolicyReconciler) processDependencies(ctx context.Context, dClient dyna
 func generatePendingErr(dependencyFailures []depclient.ObjectIdentifier) error {
 	names := make([]string, len(dependencyFailures))
 	for i, dep := range dependencyFailures {
-		names[i] = dep.Name
+		names[i] = fmt.Sprintf("%s %s", dep.Kind, dep.Name)
 	}
 
 	nameStr := strings.Join(names, ", ")

--- a/test/e2e/case12_ordering_test.go
+++ b/test/e2e/case12_ordering_test.go
@@ -40,7 +40,7 @@ func generateEventOnPolicy(plcName string, cfgPlcNamespacedName string, eventTyp
 		msg)
 }
 
-var _ = Describe("Test status sync", Ordered, func() {
+var _ = Describe("Test dependency logic in template sync", Ordered, func() {
 	AfterEach(func() {
 		opt := metav1.ListOptions{}
 		utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 0, true, defaultTimeoutSeconds)


### PR DESCRIPTION
changes the list of failed dependencies in the status from just "namespace.name" to "kind namespace.name" to make the status message more clear

Signed-off-by: Will Kutler <wkutler@redhat.com>