### PR TITLE
Use cluster namespace for known policy types

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -21,6 +21,7 @@ jobs:
     env:
       REGISTRY: localhost:5000
     strategy:
+      fail-fast: false
       matrix:
         # Run tests on oldest and newest supported OCP Kubernetes
         # - OCP 4.5 runs Kubernetes v1.18

--- a/controllers/templatesync/template_sync.go
+++ b/controllers/templatesync/template_sync.go
@@ -518,9 +518,18 @@ func (r *PolicyReconciler) processDependencies(ctx context.Context, dClient dyna
 			return nil, err
 		}
 
-		// set up namespace for replicated policy dependencies
 		ns := dep.Namespace
+
+		// infer namespace if not provided
 		if ns == "" {
+			ns = r.ClusterNamespace
+		}
+
+		// override given namespace if one of our policy types
+		// (these will always be in the cluster namespace)
+		if dep.Group == policiesv1.GroupVersion.Group &&
+			dep.Version == policiesv1.GroupVersion.Version &&
+			strings.HasSuffix(dep.Kind, "Policy") {
 			ns = r.ClusterNamespace
 		}
 

--- a/test/resources/case12_ordering/case12-plc-multiple-deps.yaml
+++ b/test/resources/case12_ordering/case12-plc-multiple-deps.yaml
@@ -13,7 +13,7 @@ spec:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: Policy
       name: namespace-foo-setup-policy
-      namespace: ""
+      namespace: this-should-be-ignored
       compliance: Compliant
   policy-templates:
     - extraDependencies:


### PR DESCRIPTION
Policies and ConfigurationPolicies should all exist in the cluster namespace, so setting a dependency with one of those types that uses another namespace is generally incorrect. The main use of the namespace field is to identify root policies in other namespaces, but that is handled in the propagator when the dependencies are canonicalized.

This keeps open the possibility of defining dependency on user-created policy types which won't necessarily follow this rule, and could have a meaningful namespace.

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>