### PR TITLE
emit pending on mapping error

### DIFF
--- a/test/resources/case12_ordering/case12-plc-invalid-dep.yaml
+++ b/test/resources/case12_ordering/case12-plc-invalid-dep.yaml
@@ -1,0 +1,36 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: case12-test-policy-invalid
+  labels:
+    policy.open-cluster-management.io/cluster-name: managed
+    policy.open-cluster-management.io/cluster-namespace: managed
+    policy.open-cluster-management.io/root-policy: case12-test-policy
+spec:
+  remediationAction: inform
+  disabled: false
+  dependencies:
+    - apiVersion: invalid.api.group/v1
+      kind: Policy
+      name: namespace-foo-setup-policy
+      namespace: ""
+      compliance: Compliant
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: case12-config-policy-invalid
+        spec:
+          remediationAction: inform
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Pod
+                metadata:
+                  name: nginx-pod-e2e
+                  namespace: default
+                spec:
+                  containers:
+                    - name: nginx


### PR DESCRIPTION
Signed-off-by: Will Kutler <wkutler@redhat.com>

Previously we were generating violations on mapping errors for dependencies (ex: wrong API group for a dependency). @JustinKuli and I decided this was a bit confusing for users, since the NonCompliant status generated by this error gives the impression that the dependency passed and the policy generated a violation, rather than the other way around. This change makes all mapping errors show the same Pending status as dependencies that are correctly formatted but do not exist.