### PR TITLE
Handle ignorePending differently

### DIFF
--- a/controllers/statussync/policy_status_sync.go
+++ b/controllers/statussync/policy_status_sync.go
@@ -205,8 +205,6 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 
 	reqLogger.Info("Updating status for policy templates")
 
-	shouldSkipPending := map[*policiesv1.DetailsPerTemplate]bool{}
-
 	for _, policyT := range instance.Spec.PolicyTemplates {
 		object, _, err := unstructured.UnstructuredJSONScheme.Decode(policyT.ObjectDefinition.Raw, nil, nil)
 		if err != nil {
@@ -344,9 +342,6 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 		// append existingDpt to status
 		newStatus.Details = append(newStatus.Details, existingDpt)
 
-		// build a map to determine whether to skip pending status from this template
-		shouldSkipPending[existingDpt] = policyT.IgnorePending
-
 		reqLogger.Info("Status update complete", "PolicyTemplate", tName)
 	}
 
@@ -360,7 +355,7 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 			isCompliant = false
 
 			break
-		} else if dpt.ComplianceState == "Pending" && !shouldSkipPending[dpt] {
+		} else if dpt.ComplianceState == "Pending" {
 			instance.Status.ComplianceState = policiesv1.Pending
 			isCompliant = false
 		} else if dpt.ComplianceState == "" {

--- a/test/resources/case12_ordering/case12-plc-ignorepending.yaml
+++ b/test/resources/case12_ordering/case12-plc-ignorepending.yaml
@@ -1,0 +1,38 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: case12-test-policy-ignorepending
+  labels:
+    policy.open-cluster-management.io/cluster-name: managed
+    policy.open-cluster-management.io/cluster-namespace: managed
+    policy.open-cluster-management.io/root-policy: case12-test-policy
+spec:
+  remediationAction: inform
+  disabled: false
+  dependencies:
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      name: namespace-foo-setup-policy
+      namespace: ""
+      compliance: Compliant
+  policy-templates:
+    - ignorePending: true
+      objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: case12-config-policy
+        spec:
+          remediationAction: inform
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Pod
+                metadata:
+                  name: nginx-pod-e2e
+                  namespace: default
+                spec:
+                  containers:
+                    - name: nginx
+


### PR DESCRIPTION
Previously, individual templates were always marked as "Pending" if they
had an unsatisfied dependency. The `ignorePending` field was only
considered when calculating the overall compliance of a Policy. But that
meant that it was not possible to correctly calculate the overall state
with just the status object, which is confusing.

Now, the `ignorePending` field is considered when marking the compliance
of each template. This makes how the overall compliance is calculated
more clear, and the new messages may be more helpful for users.

Refs:
- https://issues.redhat.com/browse/ACM-2101
