### PR TITLE
Expose metrics

### DIFF
--- a/controllers/templatesync/template_sync.go
+++ b/controllers/templatesync/template_sync.go
@@ -507,11 +507,7 @@ func (r *PolicyReconciler) processDependencies(ctx context.Context, dClient dyna
 		if depMapping != nil {
 			rsrc = depMapping.Resource
 		} else {
-			tLogger.Error(err, "Could not find an API mapping for the dependency",
-				"group", depGvk.Group,
-				"version", depGvk.Version,
-				"kind", depGvk.Kind,
-			)
+			tLogger.Error(err, "Could not find an API mapping for the dependency", "object", dep)
 
 			dependencyFailures = append(dependencyFailures, dep)
 
@@ -529,17 +525,17 @@ func (r *PolicyReconciler) processDependencies(ctx context.Context, dClient dyna
 
 		depObj, err := res.Get(ctx, dep.Name, metav1.GetOptions{})
 		if err != nil {
-			tLogger.Info("Failed to get dependency object", "object", depGvk)
+			tLogger.Info("Failed to get dependency object", "object", dep)
 
 			dependencyFailures = append(dependencyFailures, dep)
 		} else {
 			depCompliance, found, err := unstructured.NestedString(depObj.Object, "status", "compliant")
 			if err != nil || !found {
-				tLogger.Info("Failed to get compliance for dependency object", "object", depGvk)
+				tLogger.Info("Failed to get compliance for dependency object", "object", dep)
 
 				dependencyFailures = append(dependencyFailures, dep)
 			} else if depCompliance != templateDeps[dep] {
-				tLogger.Info("Compliance mismatch for dependency object", "object", depGvk)
+				tLogger.Info("Compliance mismatch for dependency object", "object", dep)
 
 				dependencyFailures = append(dependencyFailures, dep)
 			}

--- a/main.go
+++ b/main.go
@@ -162,7 +162,7 @@ func main() {
 	mgrOptionsBase := manager.Options{
 		LeaderElection: tool.Options.EnableLeaderElection,
 		// Disable the metrics endpoint
-		MetricsBindAddress: "0",
+		MetricsBindAddress: tool.Options.MetricsAddr,
 		Scheme:             scheme,
 		// Override the EventBroadcaster so that the spam filter will not ignore events for the policy but with
 		// different messages if a large amount of events for that policy are sent in a short time.
@@ -445,6 +445,10 @@ func getHubManager(
 	options.LeaderElectionConfig = managedCfg
 	options.Namespace = tool.Options.ClusterNamespaceOnHub
 	options.NewCache = newCacheFunc
+
+	// Disable the metrics endpoint for this manager. Note that since they both use the global
+	// metrics registry, metrics for this manager are still exposed by the other manager.
+	options.MetricsBindAddress = "0"
 
 	// Create a new manager to provide shared dependencies and start components
 	mgr, err := ctrl.NewManager(hubCfg, options)

--- a/test/e2e/case13_metrics_test.go
+++ b/test/e2e/case13_metrics_test.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2020 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package e2e
+
+import (
+	"os/exec"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// getMetrics curls the metrics endpoint, filters the response with the given patterns,
+// and returns the value(s) for the matching metric(s).
+func getMetrics(metricPatterns ...string) []string {
+	metricFilter := " | grep " + strings.Join(metricPatterns, " | grep ")
+	metricsCmd := `curl localhost:8383/metrics` + metricFilter
+	cmd := exec.Command("bash", "-c", metricsCmd)
+
+	matchingMetricsRaw, err := cmd.Output()
+	if err != nil {
+		if err.Error() == "exit status 1" {
+			return []string{} // exit 1 indicates that grep couldn't find a match.
+		}
+
+		return []string{err.Error()}
+	}
+
+	matchingMetrics := strings.Split(strings.TrimSpace(string(matchingMetricsRaw)), "\n")
+	values := make([]string, len(matchingMetrics))
+
+	for i, metric := range matchingMetrics {
+		fields := strings.Fields(metric)
+		if len(fields) > 0 {
+			values[i] = fields[len(fields)-1]
+		}
+	}
+
+	return values
+}
+
+var _ = Describe("Test metrics are exposed", Ordered, func() {
+	It("Should expose the controller runtime reconcile total for each controller", func() {
+		controllers := []string{
+			"policy-spec-sync",
+			"policy-status-sync",
+			"policy-template-sync",
+			"secret-sync",
+		}
+
+		for _, ctrl := range controllers {
+			By("Checking for the " + ctrl + " controller metric")
+			matches := getMetrics("controller_runtime_reconcile_total", "success", ctrl)
+			Expect(matches).To(HaveLen(1))
+		}
+	})
+})

--- a/tool/options.go
+++ b/tool/options.go
@@ -20,6 +20,7 @@ type SyncerOptions struct {
 	EnableLeaderElection      bool
 	LegacyLeaderElection      bool
 	ProbeAddr                 string
+	MetricsAddr               string
 	// The namespace that the replicated policies should be synced to. This defaults to the same namespace as on the
 	// Hub.
 	ClusterNamespace string
@@ -94,5 +95,12 @@ func ProcessFlags() {
 		"health-probe-bind-address",
 		":8080",
 		"The address the first probe endpoint binds to.",
+	)
+
+	flag.StringVar(
+		&Options.MetricsAddr,
+		"metrics-bind-address",
+		"localhost:8383",
+		"The address the metrics endpoint binds to.",
 	)
 }


### PR DESCRIPTION
By default, the metrics are exposed at localhost:8383. Note that this means in a pod, workloads outside the pod *can not* access them.

Refs:
 - https://issues.redhat.com/browse/ACM-2179

Also includes a minor improvement to logs for dependencies.