### PR TITLE
Clean up policy templates that have been removed from the parent policy

### DIFF
--- a/controllers/templatesync/template_sync.go
+++ b/controllers/templatesync/template_sync.go
@@ -12,11 +12,14 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/prometheus/client_golang/prometheus"
 	depclient "github.com/stolostron/kubernetes-dependency-watches/client"
+	extensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	extensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -36,14 +39,17 @@ import (
 )
 
 const (
-	ControllerName string = "policy-template-sync"
-	policyFmtStr   string = "policy: %s/%s"
+	ControllerName    string = "policy-template-sync"
+	policyFmtStr      string = "policy: %s/%s"
+	PolicyTypeLabel   string = "policy.open-cluster-management.io/policy-type"
+	parentPolicyLabel string = "policy.open-cluster-management.io/policy"
 )
 
 var log = ctrl.Log.WithName(ControllerName)
 
 //+kubebuilder:rbac:groups=policy.open-cluster-management.io,resources=*,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=events,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list
 
 // Setup sets up the controller
 func (r *PolicyReconciler) Setup(mgr ctrl.Manager, depEvents *source.Channel) error {
@@ -177,6 +183,8 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 	// As a quirk of the error handling, only the last occurring error is "returned" by Reconcile.
 	var resultError error
 
+	var templateNames []string
+
 	// PolicyTemplates is not empty
 	// loop through policy templates
 	for tIndex, policyT := range instance.Spec.PolicyTemplates {
@@ -258,6 +266,8 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 
 			continue
 		}
+
+		templateNames = append(templateNames, tName)
 
 		tLogger := reqLogger.WithValues("template", tName)
 
@@ -354,6 +364,9 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 					labels["cluster-namespace"] = instance.GetLabels()[common.ClusterNamespaceLabel]
 					labels[common.ClusterNamespaceLabel] = instance.GetLabels()[common.ClusterNamespaceLabel]
 				}
+
+				// set label to identify parent policy for this template
+				labels[parentPolicyLabel] = instance.GetName()
 
 				tObjectUnstructured.SetLabels(labels)
 				tObjectUnstructured.SetOwnerReferences([]metav1.OwnerReference{plcOwnerReferences})
@@ -523,9 +536,95 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 		policySystemErrorsCounter.WithLabelValues(instance.Name, "", "client-error").Inc()
 	}
 
+	err = r.cleanUpExcessTemplates(ctx, dClient, *instance, templateNames)
+	if err != nil {
+		resultError = err
+		reqLogger.Error(resultError, "Error cleaning up templates")
+	}
+
 	reqLogger.Info("Completed the reconciliation")
 
 	return reconcile.Result{}, resultError
+}
+
+// cleanUpExcessTemplates compares existing policy templates on the cluster to those contained in the policy,
+// and deletes those that have been renamed or removed from the parent policy
+func (r *PolicyReconciler) cleanUpExcessTemplates(
+	ctx context.Context,
+	dClient dynamic.Interface,
+	instance policiesv1.Policy,
+	templateNames []string,
+) error {
+	crdLabelSelector := labels.SelectorFromSet(map[string]string{PolicyTypeLabel: "template"})
+	crdsv1 := extensionsv1.CustomResourceDefinitionList{}
+	tmplGVRs := []schema.GroupVersionResource{}
+
+	// build list of GVRs for templates to check the parent label on
+	err := r.List(ctx, &crdsv1, &client.ListOptions{LabelSelector: crdLabelSelector})
+	if err == nil {
+		for _, crd := range crdsv1.Items {
+			if len(crd.Spec.Versions) > 0 {
+				tmplGVRs = append(tmplGVRs, schema.GroupVersionResource{
+					Group:    crd.Spec.Group,
+					Resource: crd.Spec.Names.Plural,
+					Version:  crd.Spec.Versions[0].Name,
+				})
+			}
+		}
+	} else if meta.IsNoMatchError(err) {
+		crdsv1beta1 := extensionsv1beta1.CustomResourceDefinitionList{}
+		err := r.List(ctx, &crdsv1beta1, &client.ListOptions{LabelSelector: crdLabelSelector})
+		if err != nil {
+			return fmt.Errorf("error listing v1beta1 CRDs with %s label: %w", crdLabelSelector, err)
+		}
+		for _, crd := range crdsv1beta1.Items {
+			if len(crd.Spec.Versions) > 0 {
+				tmplGVRs = append(tmplGVRs, schema.GroupVersionResource{
+					Group:    crd.Spec.Group,
+					Resource: crd.Spec.Names.Plural,
+					Version:  crd.Spec.Versions[0].Name,
+				})
+			}
+		}
+	} else {
+		return fmt.Errorf("error listing v1 CRDs with %s label: %w", crdLabelSelector, err)
+	}
+
+	for _, gvr := range tmplGVRs {
+		// iterate through all templates with parent label set to see if they match
+		children, err := dClient.Resource(gvr).Namespace(r.ClusterNamespace).List(ctx, metav1.ListOptions{
+			LabelSelector: parentPolicyLabel + "=" + instance.GetName(),
+		})
+		if err != nil {
+			return fmt.Errorf("error listing %s objects: %w", gvr.String(), err)
+		}
+
+		for _, tmpl := range children.Items {
+			// delete all templates with label that aren't still in the policy
+			found := false
+
+			for _, parentTmplName := range templateNames {
+				if parentTmplName == tmpl.GetName() {
+					found = true
+
+					break
+				}
+			}
+
+			if !found {
+				err := dClient.Resource(schema.GroupVersionResource{
+					Group:    gvr.Group,
+					Version:  gvr.Version,
+					Resource: gvr.Resource,
+				}).Namespace(r.ClusterNamespace).Delete(ctx, tmpl.GetName(), metav1.DeleteOptions{})
+				if err != nil {
+					return fmt.Errorf("error deleting %s object %s: %w", gvr.String(), tmpl.GetName(), err)
+				}
+			}
+		}
+	}
+
+	return nil
 }
 
 // processDependencies iterates through all dependencies of a template and returns an array of any that are not met

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -49,6 +49,13 @@ metadata:
   name: governance-policy-framework-addon
 rules:
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+- apiGroups:
   - ""
   resources:
   - events

--- a/deploy/rbac/role.yaml
+++ b/deploy/rbac/role.yaml
@@ -7,6 +7,13 @@ metadata:
   name: governance-policy-framework-addon
 rules:
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+- apiGroups:
   - ""
   resources:
   - events

--- a/test/e2e/case15_template_cleanup_test.go
+++ b/test/e2e/case15_template_cleanup_test.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2020 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"open-cluster-management.io/governance-policy-propagator/test/utils"
+)
+
+const (
+	case15PolicyName             string = "case15-test-policy"
+	case15PolicyYaml             string = "../resources/case15_template_cleanup/case15-test-policy.yaml"
+	case15PolicyYamlPatchRename  string = "../resources/case15_template_cleanup/case15-test-policy-patch-rename.yaml"
+	case15PolicyYamlPatchDelete  string = "../resources/case15_template_cleanup/case15-test-policy-patch-delete.yaml"
+	case15ConfigPolicyName       string = "case15-config-policy"
+	case15ConfigPolicyRenamed    string = "case15-config-policy-renamed"
+	case15ConfigPolicyNameStable string = "case15-config-policy-stable"
+)
+
+var _ = Describe("Test template sync", func() {
+	BeforeEach(func() {
+		By("Creating a policy on the hub in ns:" + clusterNamespaceOnHub)
+		_, err := kubectlHub("apply", "-f", case15PolicyYaml, "-n", clusterNamespaceOnHub)
+		Expect(err).Should(BeNil())
+		plc := utils.GetWithTimeout(clientManagedDynamic, gvrPolicy, case15PolicyName, clusterNamespace, true,
+			defaultTimeoutSeconds)
+		Expect(plc).NotTo(BeNil())
+	})
+	AfterEach(func() {
+		By("Deleting a policy on the hub in ns:" + clusterNamespaceOnHub)
+		_, err := kubectlHub("delete", "-f", case15PolicyYaml, "-n", clusterNamespaceOnHub, "--ignore-not-found=true")
+		Expect(err).To(BeNil())
+		opt := metav1.ListOptions{}
+		utils.ListWithTimeout(clientManagedDynamic, gvrPolicy, opt, 0, true, defaultTimeoutSeconds)
+	})
+	It("should create policy template on managed cluster and remove it on rename", func() {
+		By("Checking the configpolicy CRs")
+		yamlPlc := utils.ParseYaml("../resources/case15_template_cleanup/case15-config-policy-rename.yaml")
+		Eventually(func() interface{} {
+			trustedPlc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigurationPolicy,
+				case15ConfigPolicyName, clusterNamespace, true, defaultTimeoutSeconds)
+
+			return trustedPlc.Object["spec"]
+		}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["spec"]))
+		yamlStablePlc := utils.ParseYaml("../resources/case15_template_cleanup/case15-config-policy-stable.yaml")
+		Eventually(func() interface{} {
+			trustedPlc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigurationPolicy,
+				case15ConfigPolicyNameStable, clusterNamespace, true, defaultTimeoutSeconds)
+
+			return trustedPlc.Object["spec"]
+		}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlStablePlc.Object["spec"]))
+
+		By("Renaming one of the configurationpolicies")
+		_, err := kubectlHub("apply", "-f", case15PolicyYamlPatchRename, "-n", clusterNamespaceOnHub)
+		Expect(err).Should(BeNil())
+		plc := utils.GetWithTimeout(clientManagedDynamic, gvrPolicy, case15PolicyName, clusterNamespace, true,
+			defaultTimeoutSeconds)
+		Expect(plc).NotTo(BeNil())
+
+		By("Verifying the changed config policy has been deleted and the stable one still exists")
+		cfgplc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigurationPolicy, case15ConfigPolicyNameStable,
+			clusterNamespace, true, defaultTimeoutSeconds)
+		Expect(cfgplc).NotTo(BeNil())
+		cfgplc = utils.GetWithTimeout(clientManagedDynamic, gvrConfigurationPolicy, case15ConfigPolicyRenamed,
+			clusterNamespace, true, defaultTimeoutSeconds)
+		Expect(cfgplc).NotTo(BeNil())
+		cfgplc = utils.GetWithTimeout(clientManagedDynamic, gvrConfigurationPolicy, case15ConfigPolicyName,
+			clusterNamespace, false, defaultTimeoutSeconds)
+		Expect(cfgplc).To(BeNil())
+
+		By("Verifying the spec is correct for both existing CRs")
+		yamlPlc = utils.ParseYaml("../resources/case15_template_cleanup/case15-config-policy-rename.yaml")
+		Eventually(func() interface{} {
+			trustedPlc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigurationPolicy,
+				case15ConfigPolicyRenamed, clusterNamespace, true, defaultTimeoutSeconds)
+
+			return trustedPlc.Object["spec"]
+		}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["spec"]))
+		yamlStablePlc = utils.ParseYaml("../resources/case15_template_cleanup/case15-config-policy-stable.yaml")
+		Eventually(func() interface{} {
+			trustedPlc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigurationPolicy,
+				case15ConfigPolicyNameStable, clusterNamespace, true, defaultTimeoutSeconds)
+
+			return trustedPlc.Object["spec"]
+		}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlStablePlc.Object["spec"]))
+
+		By("Removing one of the configurationpolicies")
+		_, err = kubectlHub("apply", "-f", case15PolicyYamlPatchDelete, "-n", clusterNamespaceOnHub)
+		Expect(err).Should(BeNil())
+		plc = utils.GetWithTimeout(clientManagedDynamic, gvrPolicy, case15PolicyName, clusterNamespace, true,
+			defaultTimeoutSeconds)
+		Expect(plc).NotTo(BeNil())
+
+		By("Verifying the removed config policy has been deleted and the stable one still exists")
+		cfgplc = utils.GetWithTimeout(clientManagedDynamic, gvrConfigurationPolicy, case15ConfigPolicyNameStable,
+			clusterNamespace, true, defaultTimeoutSeconds)
+		Expect(cfgplc).NotTo(BeNil())
+		cfgplc = utils.GetWithTimeout(clientManagedDynamic, gvrConfigurationPolicy, case15ConfigPolicyRenamed,
+			clusterNamespace, false, defaultTimeoutSeconds)
+		Expect(cfgplc).To(BeNil())
+	})
+})

--- a/test/resources/case15_template_cleanup/case15-config-policy-rename.yaml
+++ b/test/resources/case15_template_cleanup/case15-config-policy-rename.yaml
@@ -1,0 +1,18 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: case15-config-policy
+spec:
+  remediationAction: inform
+  pruneObjectBehavior: "None"
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          name: nginx-pod-e2e
+          namespace: default
+        spec:
+          containers:
+            - name: nginx

--- a/test/resources/case15_template_cleanup/case15-config-policy-stable.yaml
+++ b/test/resources/case15_template_cleanup/case15-config-policy-stable.yaml
@@ -1,0 +1,17 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: case15-config-policy-stable
+spec:
+  remediationAction: inform
+  pruneObjectBehavior: "None"
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: demo-templates
+          namespace: test
+        data:
+          app-name: sampleApp

--- a/test/resources/case15_template_cleanup/case15-test-policy-patch-delete.yaml
+++ b/test/resources/case15_template_cleanup/case15-test-policy-patch-delete.yaml
@@ -1,0 +1,29 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: case15-test-policy
+  labels:
+    policy.open-cluster-management.io/cluster-name: managed
+    policy.open-cluster-management.io/cluster-namespace: managed
+    policy.open-cluster-management.io/root-policy: case9-test-policy
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: case15-config-policy-stable
+        spec:
+          remediationAction: inform
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: ConfigMap
+                metadata:
+                  name: demo-templates
+                  namespace: test
+                data:
+                  app-name: sampleApp

--- a/test/resources/case15_template_cleanup/case15-test-policy-patch-rename.yaml
+++ b/test/resources/case15_template_cleanup/case15-test-policy-patch-rename.yaml
@@ -1,0 +1,47 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: case15-test-policy
+  labels:
+    policy.open-cluster-management.io/cluster-name: managed
+    policy.open-cluster-management.io/cluster-namespace: managed
+    policy.open-cluster-management.io/root-policy: case9-test-policy
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: case15-config-policy-renamed
+        spec:
+          remediationAction: inform
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Pod
+                metadata:
+                  name: nginx-pod-e2e
+                  namespace: default
+                spec:
+                  containers:
+                    - name: nginx
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: case15-config-policy-stable
+        spec:
+          remediationAction: inform
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: ConfigMap
+                metadata:
+                  name: demo-templates
+                  namespace: test
+                data:
+                  app-name: sampleApp

--- a/test/resources/case15_template_cleanup/case15-test-policy.yaml
+++ b/test/resources/case15_template_cleanup/case15-test-policy.yaml
@@ -1,0 +1,48 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: case15-test-policy
+  labels:
+    policy.open-cluster-management.io/cluster-name: managed
+    policy.open-cluster-management.io/cluster-namespace: managed
+    policy.open-cluster-management.io/root-policy: case9-test-policy
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: case15-config-policy
+        spec:
+          remediationAction: inform
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Pod
+                metadata:
+                  name: nginx-pod-e2e
+                  namespace: default
+                spec:
+                  containers:
+                    - name: nginx
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: case15-config-policy-stable
+        spec:
+          remediationAction: inform
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: ConfigMap
+                metadata:
+                  name: demo-templates
+                  namespace: test
+                data:
+                  app-name: sampleApp
+


### PR DESCRIPTION
Adds a label to policy templates that are created as a child of a policy, then compares the policy templates actually contained in that policy to all templates with the parent policy label to determine if templates have been renamed or removed from the parent. The template sync will then clean up any policy templates that are not being managed by the parent policy that created them.

refs:
- https://issues.redhat.com/browse/ACM-3049?filter=-1

Signed-off-by: Will Kutler <wkutler@redhat.com>