### PR TITLE
Unowned template panic

### DIFF
--- a/test/e2e/case11_status_ts_collision_test.go
+++ b/test/e2e/case11_status_ts_collision_test.go
@@ -103,12 +103,9 @@ func case11cleanup() {
 
 var _ = Describe("Test event sorting by name when timestamps collide", Ordered, func() {
 	It("Creates the policy and one event, and shows compliant", func() {
-		_, err := utils.KubectlWithOutput(
-			"apply", "-f", case11PolicyYaml, "-n", clusterNamespaceOnHub, case11hubconfig,
-		)
-		Expect(err).Should(BeNil())
+		hubApplyPolicy(case11PolicyName, case11PolicyYaml)
 
-		_, err = utils.KubectlWithOutput(
+		_, err := utils.KubectlWithOutput(
 			"apply", "-f", case11PolicyYaml, "-n", clusterNamespace, case11managedconfig,
 		)
 		Expect(err).Should(BeNil())
@@ -165,12 +162,9 @@ var _ = Describe("Test event sorting by name when timestamps collide", Ordered, 
 
 var _ = Describe("Test event sorting by eventtime when timestamps collide", Ordered, func() {
 	It("Creates the policy and one event, and shows compliant", func() {
-		_, err := utils.KubectlWithOutput(
-			"apply", "-f", case11PolicyYaml, "-n", clusterNamespaceOnHub, case11hubconfig,
-		)
-		Expect(err).Should(BeNil())
+		hubApplyPolicy(case11PolicyName, case11PolicyYaml)
 
-		_, err = utils.KubectlWithOutput(
+		_, err := utils.KubectlWithOutput(
 			"apply", "-f", case11PolicyYaml, "-n", clusterNamespace, case11managedconfig,
 		)
 		Expect(err).Should(BeNil())

--- a/test/e2e/case12_ordering_test.go
+++ b/test/e2e/case12_ordering_test.go
@@ -45,21 +45,11 @@ var _ = Describe("Test dependency logic in template sync", Ordered, func() {
 	)
 
 	hubPolicyApplyAndDeferCleanup := func(yamlFile, policyName string) {
-		_, err := kubectlHub("apply", "-f", yamlFile, "-n", clusterNamespaceOnHub)
-		Expect(err).To(BeNil())
-
-		hubPlc := utils.GetWithTimeout(
-			clientHubDynamic,
-			gvrPolicy,
-			policyName,
-			clusterNamespaceOnHub,
-			true,
-			defaultTimeoutSeconds)
-		Expect(hubPlc).NotTo(BeNil())
+		hubApplyPolicy(policyName, yamlFile)
 
 		DeferCleanup(func() {
 			By("Deleting policy " + policyName + " on hub cluster in ns: " + clusterNamespaceOnHub)
-			_, err = kubectlHub("delete", "-f", yamlFile, "-n", clusterNamespaceOnHub)
+			_, err := kubectlHub("delete", "-f", yamlFile, "-n", clusterNamespaceOnHub)
 			Expect(err).To(BeNil())
 		})
 	}

--- a/test/e2e/case14_user_metrics_test.go
+++ b/test/e2e/case14_user_metrics_test.go
@@ -31,14 +31,8 @@ var _ = Describe("Test user error metrics", Ordered, func() {
 	AfterAll(cleanup)
 
 	It("Should increment user error metric on user error", func() {
-		By(
-			"Creating policy " + policyName + " on hub cluster " +
-				"in ns:" + clusterNamespaceOnHub,
-		)
-		_, err := kubectlHub(
-			"apply", "-f", policyFile, "-n", clusterNamespaceOnHub,
-		)
-		Expect(err).Should(BeNil())
+		hubApplyPolicy(policyName, policyFile)
+
 		By("Checking for the " + metricName + " metric on the template-sync controller")
 		values := []string{}
 		Eventually(func() []string {

--- a/test/e2e/case1_mutation_recovery_test.go
+++ b/test/e2e/case1_mutation_recovery_test.go
@@ -13,25 +13,16 @@ import (
 	"open-cluster-management.io/governance-policy-propagator/test/utils"
 )
 
-const (
-	case1PolicyName string = "case1-test-policy"
-	case1PolicyYaml string = "../resources/case1_mutation_recovery/case1-test-policy.yaml"
-)
-
 var _ = Describe("Test mutation recovery", func() {
+	const (
+		case1PolicyName string = "case1-test-policy"
+		case1PolicyYaml string = "../resources/case1_mutation_recovery/case1-test-policy.yaml"
+	)
+
 	BeforeEach(func() {
-		By("Creating a policy on hub cluster in ns:" + clusterNamespaceOnHub)
-		_, err := kubectlHub("apply", "-f", case1PolicyYaml, "-n", clusterNamespaceOnHub)
-		Expect(err).Should(BeNil())
-		hubPlc := utils.GetWithTimeout(
-			clientHubDynamic,
-			gvrPolicy,
-			case1PolicyName,
-			clusterNamespaceOnHub,
-			true,
-			defaultTimeoutSeconds)
-		Expect(hubPlc).NotTo(BeNil())
+		hubApplyPolicy(case1PolicyName, case1PolicyYaml)
 	})
+
 	AfterEach(func() {
 		By("Deleting a policy on hub cluster in ns:" + clusterNamespaceOnHub)
 		_, err := kubectlHub("delete", "-f", case1PolicyYaml, "-n", clusterNamespaceOnHub)

--- a/test/e2e/case2_status_sync_test.go
+++ b/test/e2e/case2_status_sync_test.go
@@ -14,24 +14,14 @@ import (
 	"open-cluster-management.io/governance-policy-propagator/test/utils"
 )
 
-const (
-	case2PolicyName string = "case2-test-policy"
-	case2PolicyYaml string = "../resources/case2_status_sync/case2-test-policy.yaml"
-)
-
 var _ = Describe("Test status sync", func() {
+	const (
+		case2PolicyName string = "case2-test-policy"
+		case2PolicyYaml string = "../resources/case2_status_sync/case2-test-policy.yaml"
+	)
+
 	BeforeEach(func() {
-		By("Creating a policy on hub cluster in ns:" + clusterNamespaceOnHub)
-		_, err := kubectlHub("apply", "-f", case2PolicyYaml, "-n", clusterNamespaceOnHub)
-		Expect(err).To(BeNil())
-		hubPlc := utils.GetWithTimeout(
-			clientHubDynamic,
-			gvrPolicy,
-			case2PolicyName,
-			clusterNamespaceOnHub,
-			true,
-			defaultTimeoutSeconds)
-		Expect(hubPlc).NotTo(BeNil())
+		hubApplyPolicy(case2PolicyName, case2PolicyYaml)
 	})
 	AfterEach(func() {
 		By("Deleting a policy on hub cluster in ns:" + clusterNamespaceOnHub)

--- a/test/e2e/case3_multiple_templates_test.go
+++ b/test/e2e/case3_multiple_templates_test.go
@@ -13,11 +13,6 @@ import (
 	"open-cluster-management.io/governance-policy-propagator/test/utils"
 )
 
-const (
-	case3PolicyName string = "case3-test-policy"
-	case3PolicyYaml string = "../resources/case3_multiple_templates/case3-test-policy.yaml"
-)
-
 func getCompliant(policy *unstructured.Unstructured) string {
 	status, statusOk := policy.Object["status"].(map[string]interface{})
 	if !statusOk {
@@ -33,18 +28,13 @@ func getCompliant(policy *unstructured.Unstructured) string {
 }
 
 var _ = Describe("Test status sync with multiple templates", func() {
+	const (
+		case3PolicyName string = "case3-test-policy"
+		case3PolicyYaml string = "../resources/case3_multiple_templates/case3-test-policy.yaml"
+	)
+
 	BeforeEach(func() {
-		By("Creating a policy on hub cluster in ns:" + clusterNamespaceOnHub)
-		_, err := kubectlHub("apply", "-f", case3PolicyYaml, "-n", clusterNamespaceOnHub)
-		Expect(err).To(BeNil())
-		hubPlc := utils.GetWithTimeout(
-			clientHubDynamic,
-			gvrPolicy,
-			case3PolicyName,
-			clusterNamespaceOnHub,
-			true,
-			defaultTimeoutSeconds)
-		Expect(hubPlc).NotTo(BeNil())
+		hubApplyPolicy(case3PolicyName, case3PolicyYaml)
 	})
 	AfterEach(func() {
 		if CurrentSpecReport().Failed() {

--- a/test/e2e/case4_status_merge_test.go
+++ b/test/e2e/case4_status_merge_test.go
@@ -14,24 +14,15 @@ import (
 	"open-cluster-management.io/governance-policy-propagator/test/utils"
 )
 
-const (
-	case4PolicyName string = "case4-test-policy"
-	case4PolicyYaml string = "../resources/case4_status_merge/case4-test-policy.yaml"
-)
-
 var _ = Describe("Test status sync with multiple templates", func() {
+	const (
+		case4PolicyName string = "case4-test-policy"
+		case4PolicyYaml string = "../resources/case4_status_merge/case4-test-policy.yaml"
+	)
+
 	BeforeEach(func() {
-		By("Creating a policy on hub cluster in ns:" + clusterNamespaceOnHub)
-		_, err := kubectlHub("apply", "-f", case4PolicyYaml, "-n", clusterNamespaceOnHub)
-		Expect(err).Should(BeNil())
-		hubPlc := utils.GetWithTimeout(
-			clientHubDynamic,
-			gvrPolicy,
-			case4PolicyName,
-			clusterNamespaceOnHub,
-			true,
-			defaultTimeoutSeconds)
-		Expect(hubPlc).NotTo(BeNil())
+		hubApplyPolicy(case4PolicyName, case4PolicyYaml)
+
 		managedPlc := utils.GetWithTimeout(
 			clientManagedDynamic,
 			gvrPolicy,

--- a/test/e2e/case5_error_handling_test.go
+++ b/test/e2e/case5_error_handling_test.go
@@ -1,7 +1,0 @@
-//go:build dd
-// +build dd
-
-// Copyright (c) 2020 Red Hat, Inc.
-// Copyright Contributors to the Open Cluster Management project
-
-package e2e

--- a/test/e2e/case6_event_msg_test.go
+++ b/test/e2e/case6_event_msg_test.go
@@ -12,39 +12,14 @@ import (
 	"open-cluster-management.io/governance-policy-propagator/test/utils"
 )
 
-const (
-	case6PolicyName string = "case6-test-policy"
-	case6PolicyYaml string = "../resources/case6_event_msg/case6-test-policy.yaml"
-)
-
 var _ = Describe("Test event message handling", func() {
+	const (
+		case6PolicyName string = "case6-test-policy"
+		case6PolicyYaml string = "../resources/case6_event_msg/case6-test-policy.yaml"
+	)
 	BeforeEach(func() {
-		By("Creating a policy on hub cluster in ns:" + clusterNamespaceOnHub)
-		_, err := kubectlHub(
-			"apply",
-			"-f",
-			case6PolicyYaml,
-			"-n",
-			clusterNamespaceOnHub,
-		)
-		Expect(err).Should(BeNil())
-		hubPlc := utils.GetWithTimeout(
-			clientHubDynamic,
-			gvrPolicy,
-			case6PolicyName,
-			clusterNamespaceOnHub,
-			true,
-			defaultTimeoutSeconds)
-		Expect(hubPlc).NotTo(BeNil())
-		By("Creating a policy on the hub in ns:" + clusterNamespaceOnHub)
-		_, err = kubectlHub(
-			"apply",
-			"-f",
-			case6PolicyYaml,
-			"-n",
-			clusterNamespaceOnHub,
-		)
-		Expect(err).Should(BeNil())
+		hubApplyPolicy(case6PolicyName, case6PolicyYaml)
+
 		managedPlc := utils.GetWithTimeout(
 			clientManagedDynamic,
 			gvrPolicy,

--- a/test/e2e/case7_spec_sync_test.go
+++ b/test/e2e/case7_spec_sync_test.go
@@ -10,24 +10,14 @@ import (
 	"open-cluster-management.io/governance-policy-propagator/test/utils"
 )
 
-const (
-	case7PolicyName string = "case7-test-policy"
-	case7PolicyYaml string = "../resources/case7_spec_sync/case7-test-policy.yaml"
-)
-
 var _ = Describe("Test spec sync", func() {
+	const (
+		case7PolicyName string = "case7-test-policy"
+		case7PolicyYaml string = "../resources/case7_spec_sync/case7-test-policy.yaml"
+	)
+
 	BeforeEach(func() {
-		By("Creating a policy on hub cluster in ns:" + clusterNamespaceOnHub)
-		_, err := kubectlHub("apply", "-f", case7PolicyYaml, "-n", clusterNamespaceOnHub)
-		Expect(err).Should(BeNil())
-		plc := utils.GetWithTimeout(
-			clientManagedDynamic,
-			gvrPolicy,
-			case7PolicyName,
-			clusterNamespace,
-			true,
-			defaultTimeoutSeconds)
-		Expect(plc).NotTo(BeNil())
+		hubApplyPolicy(case7PolicyName, case7PolicyYaml)
 	})
 	AfterEach(func() {
 		By("Deleting a policy on hub cluster in ns:" + clusterNamespaceOnHub)
@@ -72,23 +62,8 @@ var _ = Describe("Test spec sync", func() {
 		}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(hubPlc.Object["spec"]))
 	})
 	It("should update policy to a different policy template", func() {
-		By("Updating policy on hub with ../resources/case7_propagation/case7-test-policy2.yaml")
-		_, err := kubectlHub(
-			"apply",
-			"-f",
-			"../resources/case7_spec_sync/case7-test-policy2.yaml",
-			"-n",
-			clusterNamespaceOnHub,
-		)
-		Expect(err).Should(BeNil())
-		hubPlc := utils.GetWithTimeout(
-			clientHubDynamic,
-			gvrPolicy,
-			case7PolicyName,
-			clusterNamespaceOnHub,
-			true,
-			defaultTimeoutSeconds)
-		Expect(hubPlc).NotTo(BeNil())
+		hubApplyPolicy(case7PolicyName, "../resources/case7_spec_sync/case7-test-policy2.yaml")
+
 		yamlPlc := utils.ParseYaml("../resources/case7_spec_sync/case7-test-policy2.yaml")
 		Eventually(func() interface{} {
 			managedPlc := utils.GetWithTimeout(

--- a/test/e2e/case8_sync_secret_test.go
+++ b/test/e2e/case8_sync_secret_test.go
@@ -13,12 +13,12 @@ import (
 	"open-cluster-management.io/governance-policy-framework-addon/controllers/secretsync"
 )
 
-const (
-	case8SecretYAML          = "../resources/case8_sync_secret/secret.yaml"
-	case8UnrelatedSecretYAML = "../resources/case8_sync_secret/unrelated_secret.yaml"
-)
+var _ = Describe("Test secret sync", func() {
+	const (
+		case8SecretYAML          = "../resources/case8_sync_secret/secret.yaml"
+		case8UnrelatedSecretYAML = "../resources/case8_sync_secret/unrelated_secret.yaml"
+	)
 
-var _ = Describe("Test spec sync", func() {
 	AfterEach(func() {
 		By("Deleting the test secrets on the Hub")
 		_, _ = kubectlHub("delete", "-f", case8SecretYAML, "-n", clusterNamespaceOnHub)

--- a/test/e2e/case9_template_sync_test.go
+++ b/test/e2e/case9_template_sync_test.go
@@ -14,20 +14,15 @@ import (
 	"open-cluster-management.io/governance-policy-propagator/test/utils"
 )
 
-const (
-	case9PolicyName       string = "case9-test-policy"
-	case9PolicyYaml       string = "../resources/case9_template_sync/case9-test-policy.yaml"
-	case9ConfigPolicyName string = "case9-config-policy"
-)
-
 var _ = Describe("Test template sync", func() {
+	const (
+		case9PolicyName       string = "case9-test-policy"
+		case9PolicyYaml       string = "../resources/case9_template_sync/case9-test-policy.yaml"
+		case9ConfigPolicyName string = "case9-config-policy"
+	)
+
 	BeforeEach(func() {
-		By("Creating a policy on the hub in ns:" + clusterNamespaceOnHub)
-		_, err := kubectlHub("apply", "-f", case9PolicyYaml, "-n", clusterNamespaceOnHub)
-		Expect(err).Should(BeNil())
-		plc := utils.GetWithTimeout(clientManagedDynamic, gvrPolicy, case9PolicyName, clusterNamespace, true,
-			defaultTimeoutSeconds)
-		Expect(plc).NotTo(BeNil())
+		hubApplyPolicy(case9PolicyName, case9PolicyYaml)
 	})
 	AfterEach(func() {
 		By("Deleting a policy on the hub in ns:" + clusterNamespaceOnHub)
@@ -67,9 +62,8 @@ var _ = Describe("Test template sync", func() {
 	})
 	It("should still override remediationAction in spec when there is no remediationAction", func() {
 		By("Updating policy with no remediationAction")
-		_, err := kubectlHub("apply", "-f",
-			"../resources/case9_template_sync/case9-test-policy-no-remediation.yaml", "-n", clusterNamespaceOnHub)
-		Expect(err).Should(BeNil())
+		hubApplyPolicy(case9PolicyName, "../resources/case9_template_sync/case9-test-policy-no-remediation.yaml")
+
 		By("Checking template policy remediationAction")
 		Eventually(func() interface{} {
 			trustedPlc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigurationPolicy,

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -266,3 +266,19 @@ func checkCompliance(name string) func() string {
 		return compliant
 	}
 }
+
+func hubApplyPolicy(name, path string) {
+	By("Applying policy " + path + " to the hub in ns: " + clusterNamespaceOnHub)
+
+	_, err := kubectlHub("apply", "-f", path, "-n", clusterNamespaceOnHub)
+	ExpectWithOffset(1, err).Should(BeNil())
+
+	hubPlc := propagatorutils.GetWithTimeout(
+		clientHubDynamic,
+		gvrPolicy,
+		name,
+		clusterNamespaceOnHub,
+		true,
+		defaultTimeoutSeconds)
+	ExpectWithOffset(1, hubPlc).NotTo(BeNil())
+}

--- a/test/resources/case10_template_sync_error_test/working-policy-configpol.yaml
+++ b/test/resources/case10_template_sync_error_test/working-policy-configpol.yaml
@@ -1,0 +1,17 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: case10-config-policy
+spec:
+  remediationAction: inform
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          name: nginx-pod-e2e
+          namespace: default
+        spec:
+          containers:
+            - name: nginx


### PR DESCRIPTION
Some refactoring as well, but the more important bit is this commit:

Previously, if a Policy defined a template that already exists, it assumed that another Policy had defined it, and tried to get its owner reference in order to give a helpful error message. But if the template was created outside of a Policy, then this process would panic.

Refs:
 - https://issues.redhat.com/browse/ACM-3416