### PR TITLE
Recover owner references that are removed from policy templates

### DIFF
--- a/controllers/templatesync/template_sync.go
+++ b/controllers/templatesync/template_sync.go
@@ -185,6 +185,9 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 
 	var templateNames []string
 
+	// Array of templates managed by this policy to watch
+	var childTemplates []depclient.ObjectIdentifier
+
 	// PolicyTemplates is not empty
 	// loop through policy templates
 	for tIndex, policyT := range instance.Spec.PolicyTemplates {
@@ -266,6 +269,14 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 
 			continue
 		}
+
+		childTemplates = append(childTemplates, depclient.ObjectIdentifier{
+			Group:     gvk.Group,
+			Version:   gvk.Version,
+			Kind:      gvk.Kind,
+			Namespace: instance.GetNamespace(),
+			Name:      tName,
+		})
 
 		templateNames = append(templateNames, tName)
 
@@ -445,6 +456,25 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 			break // just get the first ownerReference, if there are any at all
 		}
 
+		parentPolicyLabel, ok := eObject.GetLabels()["policy.open-cluster-management.io/policy"]
+
+		if refName == "" && ok && parentPolicyLabel == instance.GetName() {
+			// if owner ref has been unset but the template is still managed by this policy instance,
+			// recover the owner reference
+			plcOwnerReferences := *metav1.NewControllerRef(instance, schema.GroupVersionKind{
+				Group:   policiesv1.SchemeGroupVersion.Group,
+				Version: policiesv1.SchemeGroupVersion.Version,
+				Kind:    policiesv1.Kind,
+			})
+
+			tObjectUnstructured.SetOwnerReferences([]metav1.OwnerReference{plcOwnerReferences})
+
+			refName = instance.GetName()
+		} else {
+			// otherwise, leave the owner reference as-is
+			tObjectUnstructured.SetOwnerReferences(eObject.GetOwnerReferences())
+		}
+
 		// violation if object reference and policy don't match
 		if instance.GetName() != refName {
 			var errMsg string
@@ -478,13 +508,16 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 		// got object, need to compare both spec and annotation and update
 		eObjectUnstructured := eObject.UnstructuredContent()
 		if (!equality.Semantic.DeepEqual(eObjectUnstructured["spec"], tObjectUnstructured.Object["spec"])) ||
-			(!equality.Semantic.DeepEqual(eObject.GetAnnotations(), tObjectUnstructured.GetAnnotations())) {
+			(!equality.Semantic.DeepEqual(eObject.GetAnnotations(), tObjectUnstructured.GetAnnotations())) ||
+			(!equality.Semantic.DeepEqual(eObject.GetOwnerReferences(), tObjectUnstructured.GetOwnerReferences())) {
 			// doesn't match
 			tLogger.Info("Existing object and template didn't match, will update")
 
 			eObjectUnstructured["spec"] = tObjectUnstructured.Object["spec"]
 
 			eObject.SetAnnotations(tObjectUnstructured.GetAnnotations())
+
+			eObject.SetOwnerReferences(tObjectUnstructured.GetOwnerReferences())
 
 			_, err = res.Update(ctx, eObject, metav1.UpdateOptions{})
 			if err != nil {
@@ -537,13 +570,15 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 		Name:      instance.Name,
 	}
 
-	if len(allDeps) != 0 {
-		depsToWatch := make([]depclient.ObjectIdentifier, 0, len(allDeps))
+	if len(allDeps) != 0 || len(childTemplates) != 0 {
+		objectsToWatch := make([]depclient.ObjectIdentifier, 0, len(allDeps)+len(childTemplates))
 		for depID := range allDeps {
-			depsToWatch = append(depsToWatch, depID)
+			objectsToWatch = append(objectsToWatch, depID)
 		}
 
-		err = r.DynamicWatcher.AddOrUpdateWatcher(policyObjectID, depsToWatch...)
+		objectsToWatch = append(objectsToWatch, childTemplates...)
+
+		err = r.DynamicWatcher.AddOrUpdateWatcher(policyObjectID, objectsToWatch...)
 	} else {
 		err = r.DynamicWatcher.RemoveWatcher(policyObjectID)
 	}

--- a/test/e2e/case16_restore_owner_refs_test.go
+++ b/test/e2e/case16_restore_owner_refs_test.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2020 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"open-cluster-management.io/governance-policy-propagator/test/utils"
+)
+
+var _ = Describe("Test owner reference recovery", func() {
+	const (
+		case16PolicyName            string = "case16-test-policy"
+		case16PolicyYaml            string = "../resources/case16_restore_owner_refs/case16-test-policy.yaml"
+		case16ConfigPolicyName      string = "case16-config-policy"
+		case16PatchConfigPolicyYaml string = "../resources/case16_restore_owner_refs/case16-patch-configpolicy.yaml"
+	)
+
+	BeforeEach(func() {
+		By("Creating a policy on the hub in ns:" + clusterNamespaceOnHub)
+		_, err := kubectlHub("apply", "-f", case16PolicyYaml, "-n", clusterNamespaceOnHub)
+		Expect(err).Should(BeNil())
+		plc := utils.GetWithTimeout(clientManagedDynamic, gvrPolicy, case16PolicyName, clusterNamespace, true,
+			defaultTimeoutSeconds)
+		Expect(plc).NotTo(BeNil())
+	})
+	AfterEach(func() {
+		By("Deleting a policy on the hub in ns:" + clusterNamespaceOnHub)
+		_, err := kubectlHub("delete", "-f", case16PolicyYaml, "-n", clusterNamespaceOnHub, "--ignore-not-found=true")
+		Expect(err).To(BeNil())
+		opt := metav1.ListOptions{}
+		utils.ListWithTimeout(clientManagedDynamic, gvrPolicy, opt, 0, true, defaultTimeoutSeconds)
+	})
+	It("Should restore owner references that are edited out of the child config policy", func() {
+		By("Patching config policy to remove owner references")
+		_, err := kubectlManaged("patch", "configurationpolicy", case16ConfigPolicyName, "-n", clusterNamespace,
+			"--type", "merge", "--patch-file", case16PatchConfigPolicyYaml)
+		Expect(err).Should(BeNil())
+
+		Eventually(func() interface{} {
+			configPlc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigurationPolicy,
+				case16ConfigPolicyName, clusterNamespace, true, defaultTimeoutSeconds)
+
+			md, ok := configPlc.Object["metadata"].(map[string]interface{})
+			if !ok {
+				return nil
+			}
+			ownerRefs, ok := md["ownerReferences"]
+			if !ok {
+				return nil
+			}
+
+			return ownerRefs.([]interface{})[0].(map[string]interface{})["name"]
+		}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(case16PolicyName))
+	})
+})

--- a/test/resources/case16_restore_owner_refs/case16-patch-configpolicy.yaml
+++ b/test/resources/case16_restore_owner_refs/case16-patch-configpolicy.yaml
@@ -1,0 +1,2 @@
+metadata:
+  ownerReferences: []

--- a/test/resources/case16_restore_owner_refs/case16-test-policy.yaml
+++ b/test/resources/case16_restore_owner_refs/case16-test-policy.yaml
@@ -1,0 +1,31 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: case16-test-policy
+  labels:
+    policy.open-cluster-management.io/cluster-name: managed
+    policy.open-cluster-management.io/cluster-namespace: managed
+    policy.open-cluster-management.io/root-policy: case16-test-policy
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: case16-config-policy
+        spec:
+          remediationAction: inform
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Pod
+                metadata:
+                  name: nginx-pod-e2e
+                  namespace: default
+                spec:
+                  containers:
+                    - name: nginx
+


### PR DESCRIPTION
Previously if the owner references array was removed from the metadata of a policy template, there was no way to recoveer them. With recent commits this no longer caused an index out of bounds panic, but we still want to keep the owner references, so this PR adds code to restore them if they are removed.

refs: https://issues.redhat.com/browse/ACM-3027