### PR TITLE
Remove get permission for CRDs

### DIFF
--- a/controllers/templatesync/template_sync.go
+++ b/controllers/templatesync/template_sync.go
@@ -49,7 +49,7 @@ var log = ctrl.Log.WithName(ControllerName)
 
 //+kubebuilder:rbac:groups=policy.open-cluster-management.io,resources=*,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=events,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list
+//+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=list
 
 // Setup sets up the controller
 func (r *PolicyReconciler) Setup(mgr ctrl.Manager, depEvents *source.Channel) error {

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -53,7 +53,6 @@ rules:
   resources:
   - customresourcedefinitions
   verbs:
-  - get
   - list
 - apiGroups:
   - ""

--- a/deploy/rbac/role.yaml
+++ b/deploy/rbac/role.yaml
@@ -11,7 +11,6 @@ rules:
   resources:
   - customresourcedefinitions
   verbs:
-  - get
   - list
 - apiGroups:
   - ""


### PR DESCRIPTION
https://github.com/open-cluster-management-io/governance-policy-framework-addon/pull/28 added get and list permissions for CRDs, but only list is used. This PR updates the cluster role so it doesn't have the extra get permission.