### PR TITLE
Implement syncing for `ConstraintTemplates`

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       REGISTRY: localhost:5000
+      KIND_VERSION: ${{ matrix.kind }}
     strategy:
       fail-fast: false
       matrix:
@@ -62,8 +63,6 @@ jobs:
         make test
 
     - name: Create K8s KinD Cluster - ${{ matrix.kind }}
-      env:
-        KIND_VERSION: ${{ matrix.kind }}
       run: |
         make kind-bootstrap-cluster-dev
 
@@ -81,7 +80,7 @@ jobs:
         make e2e-test-coverage
 
     - name: Test Coverage Verification
-      if: ${{ github.event_name == 'pull_request' }}
+      if: ${{ github.event_name == 'pull_request' && matrix.kind == 'latest' }}
       run: |
         make test-coverage
         make coverage-verify

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ MANAGED_CONFIG ?= $(PWD)/kubeconfig_managed
 # Set the Kind version tag
 ifeq ($(KIND_VERSION), minimum)
 	KIND_ARGS = --image kindest/node:v1.19.16
+	E2E_FILTER = --label-filter="!skip-minimum"
 else ifneq ($(KIND_VERSION), latest)
 	KIND_ARGS = --image kindest/node:$(KIND_VERSION)
 else
@@ -292,7 +293,7 @@ e2e-test: e2e-dependencies
 	$(GINKGO) -v --fail-fast --slow-spec-threshold=10s $(E2E_TEST_ARGS) test/e2e
 
 .PHONY: e2e-test-coverage
-e2e-test-coverage: E2E_TEST_ARGS = --json-report=report_e2e.json --output-dir=.
+e2e-test-coverage: E2E_TEST_ARGS = --json-report=report_e2e.json --output-dir=. $(E2E_FILTER)
 e2e-test-coverage: e2e-run-instrumented e2e-test e2e-stop-instrumented
 
 .PHONY: e2e-build-instrumented

--- a/Makefile
+++ b/Makefile
@@ -243,11 +243,11 @@ kind-bootstrap-cluster-dev: kind-create-cluster install-crds install-resources
 kind-deploy-controller:
 	@echo installing $(IMG)
 	-kubectl create ns $(KIND_NAMESPACE) --kubeconfig=$(MANAGED_CONFIG)
-	kubectl create secret -n $(KIND_NAMESPACE) generic hub-kubeconfig --from-file=kubeconfig=$(HUB_CONFIG_INTERNAL) --kubeconfig=$(MANAGED_CONFIG)
+	-kubectl create secret -n $(KIND_NAMESPACE) generic hub-kubeconfig --from-file=kubeconfig=$(HUB_CONFIG_INTERNAL) --kubeconfig=$(MANAGED_CONFIG)
 	kubectl apply -f deploy/operator.yaml -n $(KIND_NAMESPACE) --kubeconfig=$(MANAGED_CONFIG)
 
 .PHONY: kind-deploy-controller-dev
-kind-deploy-controller-dev: kind-deploy-controller
+kind-deploy-controller-dev: kind-deploy-controller build-images
 	@echo Pushing image to KinD cluster
 	kind load docker-image $(REGISTRY)/$(IMG):$(TAG) --name $(KIND_NAME)
 	@echo "Patch deployment image"

--- a/controllers/specsync/policy_spec_sync.go
+++ b/controllers/specsync/policy_spec_sync.go
@@ -18,6 +18,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"open-cluster-management.io/governance-policy-framework-addon/controllers/utils"
 )
 
 const ControllerName string = "policy-spec-sync"
@@ -110,8 +112,8 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 			managedPlc = instance.DeepCopy()
 			managedPlc.Namespace = r.TargetNamespace
 
-			if managedPlc.Labels["policy.open-cluster-management.io/cluster-namespace"] != "" {
-				managedPlc.Labels["policy.open-cluster-management.io/cluster-namespace"] = r.TargetNamespace
+			if managedPlc.Labels[common.ClusterNamespaceLabel] != "" {
+				managedPlc.Labels[common.ClusterNamespaceLabel] = r.TargetNamespace
 			}
 
 			managedPlc.SetOwnerReferences(nil)
@@ -134,7 +136,7 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 		}
 	}
 	// found, then compare and update
-	if !common.CompareSpecAndAnnotation(instance, managedPlc) {
+	if !utils.EquivalentReplicatedPolicies(instance, managedPlc) {
 		// update needed
 		reqLogger.Info("Policy mismatch between hub and managed, updating it...")
 		managedPlc.SetAnnotations(instance.GetAnnotations())

--- a/controllers/utils/utils.go
+++ b/controllers/utils/utils.go
@@ -1,0 +1,83 @@
+package utils
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	"open-cluster-management.io/governance-policy-propagator/controllers/common"
+)
+
+var (
+	GvkConstraintTemplate = schema.GroupKind{
+		Group: "templates.gatekeeper.sh",
+		Kind:  "ConstraintTemplate",
+	}
+	GConstraint = "constraints.gatekeeper.sh"
+)
+
+const (
+	PolicyFmtStr              = "policy: %s/%s"
+	PolicyClusterScopedFmtStr = "policy: %s"
+	ClusterwideFinalizer      = common.APIGroup + "/cleanup-cluster-scoped-policies"
+	ParentPolicyLabel         = common.APIGroup + "/policy"
+	PolicyTypeLabel           = common.APIGroup + "/policy-type"
+)
+
+// EquivalentReplicatedPolicies compares replicated policies. Returns true if they match. (Comparing
+// labels is skipped here in part because in hosted mode the cluster-namespace label likely will not
+// match.)
+func EquivalentReplicatedPolicies(plc1 *policiesv1.Policy, plc2 *policiesv1.Policy) bool {
+	// Compare annotations
+	if !equality.Semantic.DeepEqual(plc1.GetAnnotations(), plc2.GetAnnotations()) {
+		return false
+	}
+
+	// Compare the specs
+	return equality.Semantic.DeepEqual(plc1.Spec, plc2.Spec)
+}
+
+// ApplyObjectDefaults marshals an object to JSON using its scheme in order to fill in default
+// fields that would be added on applying the object to the cluster.
+func ApplyObjectDefaults(scheme runtime.Scheme, object *unstructured.Unstructured) error {
+	objectTyped, err := scheme.New(object.GroupVersionKind())
+	if err != nil {
+		if runtime.IsNotRegisteredError(err) {
+			return nil
+		}
+
+		return err
+	}
+
+	errDefault := fmt.Sprintf(
+		"an unexpected error occurred while filling in default fields for the %s: %%w",
+		objectTyped.GetObjectKind().GroupVersionKind().Kind,
+	)
+
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(object.Object, objectTyped)
+	if err != nil {
+		return fmt.Errorf(errDefault, err)
+	}
+
+	scheme.Default(objectTyped)
+
+	objectRaw, err := json.Marshal(objectTyped)
+	if err != nil {
+		return fmt.Errorf(errDefault, err)
+	}
+
+	objectMap := map[string]interface{}{}
+
+	err = json.Unmarshal(objectRaw, &objectMap)
+	if err != nil {
+		return fmt.Errorf(errDefault, err)
+	}
+
+	object.Object = objectMap
+
+	return nil
+}

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -56,6 +56,18 @@ rules:
   - list
   - watch
 - apiGroups:
+  - constraints.gatekeeper.sh
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - ""
   resources:
   - events
@@ -129,6 +141,18 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - templates.gatekeeper.sh
+  resources:
+  - constrainttemplates
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/deploy/rbac/role.yaml
+++ b/deploy/rbac/role.yaml
@@ -14,6 +14,18 @@ rules:
   - list
   - watch
 - apiGroups:
+  - constraints.gatekeeper.sh
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - ""
   resources:
   - events
@@ -87,3 +99,15 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - templates.gatekeeper.sh
+  resources:
+  - constrainttemplates
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/go.mod
+++ b/go.mod
@@ -3,20 +3,22 @@ module open-cluster-management.io/governance-policy-framework-addon
 go 1.19
 
 require (
-	github.com/go-logr/logr v1.2.2
+	github.com/go-logr/logr v1.2.3
 	github.com/go-logr/zapr v1.2.3
 	github.com/onsi/ginkgo/v2 v2.1.6
 	github.com/onsi/gomega v1.20.2
+	github.com/open-policy-agent/frameworks/constraint v0.0.0-20220504221328-9db6a6b27c97
 	github.com/prometheus/client_golang v1.14.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stolostron/go-log-utils v0.1.1
 	github.com/stolostron/kubernetes-dependency-watches v0.1.1
 	k8s.io/api v0.23.10
+	k8s.io/apiextensions-apiserver v0.23.5
 	k8s.io/apimachinery v0.23.10
 	k8s.io/client-go v12.0.0+incompatible
 	k8s.io/klog/v2 v2.80.0
 	open-cluster-management.io/addon-framework v0.3.0
-	open-cluster-management.io/governance-policy-propagator v0.8.1-0.20221014182333-d078c8d17ca7
+	open-cluster-management.io/governance-policy-propagator v0.10.0
 	sigs.k8s.io/controller-runtime v0.11.2
 )
 
@@ -24,11 +26,14 @@ require (
 	cloud.google.com/go v0.81.0 // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
 	github.com/Azure/go-autorest/autorest v0.11.24 // indirect
-	github.com/Azure/go-autorest/autorest/adal v0.9.18 // indirect
+	github.com/Azure/go-autorest/autorest/adal v0.9.22 // indirect
 	github.com/Azure/go-autorest/autorest/date v0.3.0 // indirect
 	github.com/Azure/go-autorest/logger v0.2.1 // indirect
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
-	github.com/avast/retry-go/v3 v3.1.1 // indirect
+	github.com/PuerkitoBio/purell v1.1.1 // indirect
+	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20210826220005-b48c857c3a0e // indirect
+	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
@@ -37,18 +42,25 @@ require (
 	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32 // indirect
+	github.com/go-openapi/jsonpointer v0.19.5 // indirect
+	github.com/go-openapi/jsonreference v0.19.6 // indirect
+	github.com/go-openapi/swag v0.21.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.2.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/cel-go v0.9.0 // indirect
 	github.com/google/go-cmp v0.5.8 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/googleapis/gnostic v0.5.5 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
+	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kr/pretty v0.3.0 // indirect
+	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
+	github.com/mitchellh/mapstructure v1.4.3 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/openshift/api v0.0.0-20211209135129-c58d9f695577 // indirect
@@ -57,23 +69,24 @@ require (
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
+	github.com/stoewer/go-strcase v1.2.0 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.21.0 // indirect
-	golang.org/x/crypto v0.0.0-20220321153916-2c7772ba3064 // indirect
+	golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa // indirect
 	golang.org/x/net v0.0.0-20220722155237-a158d28d115b // indirect
-	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b // indirect
+	golang.org/x/oauth2 v0.0.0-20220309155454-6242fa91716a // indirect
 	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect
-	golang.org/x/time v0.0.0-20220210224613-90d013bbcef8 // indirect
+	golang.org/x/time v0.0.0-20220224211638-0e9765cccd65 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/genproto v0.0.0-20220407144326-9054f6ed7bac // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/apiextensions-apiserver v0.23.5 // indirect
 	k8s.io/apiserver v0.23.5 // indirect
 	k8s.io/component-base v0.23.5 // indirect
 	k8s.io/klog v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -47,8 +47,9 @@ github.com/Azure/go-autorest/autorest v0.11.18/go.mod h1:dSiJPy22c3u0OtOKDNttNgq
 github.com/Azure/go-autorest/autorest v0.11.24 h1:1fIGgHKqVm54KIPT+q8Zmd1QlVsmHqeUGso5qm2BqqE=
 github.com/Azure/go-autorest/autorest v0.11.24/go.mod h1:G6kyRlFnTuSbEYkQGawPfsCswgme4iYf6rfSKUDzbCc=
 github.com/Azure/go-autorest/autorest/adal v0.9.13/go.mod h1:W/MM4U6nLxnIskrw4UwWzlHfGjwUS50aOsc/I3yuU8M=
-github.com/Azure/go-autorest/autorest/adal v0.9.18 h1:kLnPsRjzZZUF3K5REu/Kc+qMQrvuza2bwSnNdhmzLfQ=
 github.com/Azure/go-autorest/autorest/adal v0.9.18/go.mod h1:XVVeme+LZwABT8K5Lc3hA4nAe8LDBVle26gTrguhhPQ=
+github.com/Azure/go-autorest/autorest/adal v0.9.22 h1:/GblQdIudfEM3AWWZ0mrYJQSd7JS4S/Mbzh6F0ov0Xc=
+github.com/Azure/go-autorest/autorest/adal v0.9.22/go.mod h1:XuAbAEUv2Tta//+voMI038TrJBqjKam0me7qR+L8Cmk=
 github.com/Azure/go-autorest/autorest/date v0.3.0 h1:7gUk1U5M/CQbp9WoqinNzJar+8KY+LPI6wiWrP/myHw=
 github.com/Azure/go-autorest/autorest/date v0.3.0/go.mod h1:BI0uouVdmngYNUzGWeSYnokU+TrmwEsOqdt8Y6sso74=
 github.com/Azure/go-autorest/autorest/mocks v0.4.1 h1:K0laFcLE6VLTOwNgSxaGbUcLPuGXlNkbVvq4cW4nIHk=
@@ -64,8 +65,10 @@ github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMo
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/purell v1.1.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
+github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tNFfI=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
+github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -75,6 +78,7 @@ github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
+github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20210826220005-b48c857c3a0e h1:GCzyKMDDjSGnlpl3clrdAK7I1AaVoaiKDOYkUzChZzg=
 github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20210826220005-b48c857c3a0e/go.mod h1:F7bn7fEU90QkQ3tnmaTx3LTKLEDqnwWODIYppRQ5hnY=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
@@ -82,8 +86,8 @@ github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmV
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
-github.com/avast/retry-go/v3 v3.1.1 h1:49Scxf4v8PmiQ/nY0aY3p0hDueqSmc7++cBbtiDGu2g=
-github.com/avast/retry-go/v3 v3.1.1/go.mod h1:6cXRK369RpzFL3UQGqIUp9Q7GDrams+KsYWrfNA1/nQ=
+github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d h1:Byv0BzEl3/e6D5CLfI0j/7hiIEtvGVFPCZ7Ei2oq8iQ=
+github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
@@ -111,7 +115,11 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
+github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=
 github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
+github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
+github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
+github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h6jFvWxBdQXxjopDMZyH2UVceIRfR84bdzbkoKrsWNo=
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
@@ -165,6 +173,7 @@ github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5y
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
+github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
@@ -201,8 +210,9 @@ github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KE
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
-github.com/go-logr/logr v1.2.2 h1:ahHml/yUpnlb96Rp8HCvtYVPY8ZYpxq3g7UYchIYwbs=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/go-logr/logr v1.2.3 h1:2DntVwHkVopvECVRSlL5PSo9eG+cAkDCuckLubN+rq0=
+github.com/go-logr/logr v1.2.3/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/zapr v1.2.0/go.mod h1:Qa4Bsj2Vb+FAVeAKsLD8RLQ+YRJB8YDmOAKxaBQf7Ro=
 github.com/go-logr/zapr v1.2.3 h1:a9vnzlIBPQBBkeaR9IuMUfmVOrQlkoC4YfPoFkX3T7A=
 github.com/go-logr/zapr v1.2.3/go.mod h1:eIauM6P8qSvTw5o2ez6UEAfGjQKrxQTl5EoK+Qa2oG4=
@@ -219,6 +229,7 @@ github.com/go-openapi/jsonpointer v0.17.0/go.mod h1:cOnomiV+CVVwFLk0A/MExoFMjwds
 github.com/go-openapi/jsonpointer v0.18.0/go.mod h1:cOnomiV+CVVwFLk0A/MExoFMjwdsUdVpsRhURCKh+3M=
 github.com/go-openapi/jsonpointer v0.19.2/go.mod h1:3akKfEdA7DF1sugOqz1dVQHBcuDBPKZGEoHC/NkiQRg=
 github.com/go-openapi/jsonpointer v0.19.3/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
+github.com/go-openapi/jsonpointer v0.19.5 h1:gZr+CIYByUqjcgeLXnQu2gHYQC9o73G2XUeOFYEICuY=
 github.com/go-openapi/jsonpointer v0.19.5/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
 github.com/go-openapi/jsonreference v0.0.0-20160704190145-13c6e3589ad9/go.mod h1:W3Z9FmVs9qj+KR4zFKmDPGiLdk1D9Rlm7cyMvf57TTg=
 github.com/go-openapi/jsonreference v0.17.0/go.mod h1:g4xxGn04lDIRh0GJb5QlpE3HfopLOL6uZrK/VgnsK9I=
@@ -226,6 +237,8 @@ github.com/go-openapi/jsonreference v0.18.0/go.mod h1:g4xxGn04lDIRh0GJb5QlpE3Hfo
 github.com/go-openapi/jsonreference v0.19.2/go.mod h1:jMjeRr2HHw6nAVajTXJ4eiUwohSTlpa0o73RUL1owJc=
 github.com/go-openapi/jsonreference v0.19.3/go.mod h1:rjx6GuL8TTa9VaixXglHmQmIL98+wF9xc8zWvFonSJ8=
 github.com/go-openapi/jsonreference v0.19.5/go.mod h1:RdybgQwPxbL4UEjuAruzK1x3nE69AqPYEJeo/TWfEeg=
+github.com/go-openapi/jsonreference v0.19.6 h1:UBIxjkht+AWIgYzCDSv2GN+E/togfwXUJFRTWhl2Jjs=
+github.com/go-openapi/jsonreference v0.19.6/go.mod h1:diGHMEHg2IqXZGKxqyvWdfWU/aim5Dprw5bqpKkTvns=
 github.com/go-openapi/loads v0.17.0/go.mod h1:72tmFy5wsWx89uEVddd0RjRWPZm92WRLhf7AC+0+OOU=
 github.com/go-openapi/loads v0.18.0/go.mod h1:72tmFy5wsWx89uEVddd0RjRWPZm92WRLhf7AC+0+OOU=
 github.com/go-openapi/loads v0.19.0/go.mod h1:72tmFy5wsWx89uEVddd0RjRWPZm92WRLhf7AC+0+OOU=
@@ -249,6 +262,8 @@ github.com/go-openapi/swag v0.18.0/go.mod h1:AByQ+nYG6gQg71GINrmuDXCPWdL640yX49/
 github.com/go-openapi/swag v0.19.2/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-openapi/swag v0.19.14/go.mod h1:QYRuS/SOXUCsnplDa677K7+DxSOj6IPNl/eQntq43wQ=
+github.com/go-openapi/swag v0.21.1 h1:wm0rhTb5z7qpJRHBdPOMuY4QjVUMbF6/kwoYeRAOrKU=
+github.com/go-openapi/swag v0.21.1/go.mod h1:QYRuS/SOXUCsnplDa677K7+DxSOj6IPNl/eQntq43wQ=
 github.com/go-openapi/validate v0.18.0/go.mod h1:Uh4HdOzKt19xGIGm1qHf/ofbX1YQ4Y+MYsct2VUrAJ4=
 github.com/go-openapi/validate v0.19.2/go.mod h1:1tRCw7m3jtI8eNWEEliiAqUIcBztB2KDnRCRMUi7GTA=
 github.com/go-openapi/validate v0.19.5/go.mod h1:8DJv2CVJQ6kGNpFW6eV9N3JviE1C85nY1c2z52x1Gk4=
@@ -303,6 +318,7 @@ github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiu
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.1/go.mod h1:xXMiIv4Fb/0kKde4SpL7qlzvu5cMJDRkFDxJfI9uaxA=
+github.com/google/cel-go v0.9.0 h1:u1hg7lcZ/XWw2d3aV1jFS30ijQQ6q0/h1C2ZBeBD1gY=
 github.com/google/cel-go v0.9.0/go.mod h1:U7ayypeSkw23szu4GaQTPJGx66c20mx8JklMSxrmI1w=
 github.com/google/cel-spec v0.6.0/go.mod h1:Nwjgxy5CbjlPrtCWjeDjUyKMl8w41YBYGjsyDdqk0xA=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
@@ -396,6 +412,7 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
+github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v0.0.0-20180612202835-f2b4162afba3/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
@@ -438,6 +455,8 @@ github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
 github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
+github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
@@ -457,6 +476,8 @@ github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0Qu
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/mitchellh/mapstructure v1.4.3 h1:OVowDSCllw/YjdLkam3/sm7wEtOy59d8ndGgCcyj8cs=
+github.com/mitchellh/mapstructure v1.4.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/moby/term v0.0.0-20210610120745-9d4ed1856297/go.mod h1:vgPCkQMyxTZ7IDy8SXRufE172gr8+K/JE/7hHFxHW3A=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -492,6 +513,8 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.20.2 h1:8uQq0zMgLEfa0vRrrBgaJF2gyW9Da9BmfGV+OyUzfkY=
 github.com/onsi/gomega v1.20.2/go.mod h1:iYAIXgPSaDHak0LCMA+AWBpIKBr8WZicMxnE8luStNc=
+github.com/open-policy-agent/frameworks/constraint v0.0.0-20220504221328-9db6a6b27c97 h1:TK1HA4nZRtWNZccVk4FCsTt3Xcb5MO8nJvBQur5w8mc=
+github.com/open-policy-agent/frameworks/constraint v0.0.0-20220504221328-9db6a6b27c97/go.mod h1:AUJQpyuvY/rE/capVYxUjwER84NOq/DMo2Wn74cKs6A=
 github.com/openshift/api v0.0.0-20211209135129-c58d9f695577 h1:NUe82M8wMYXbd5s+WBAJ2QAZZivs+nhZ3zYgZFwKfqw=
 github.com/openshift/api v0.0.0-20211209135129-c58d9f695577/go.mod h1:DoslCwtqUpr3d/gsbq4ZlkaMEdYqKxuypsDjorcHhME=
 github.com/openshift/build-machinery-go v0.0.0-20210712174854-1bb7fd1518d3/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
@@ -586,6 +609,7 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
 github.com/spf13/viper v1.8.1/go.mod h1:o0Pch8wJ9BVSWGQMbra6iw0oQ5oktSIBaujf1rJH9Ns=
+github.com/stoewer/go-strcase v1.2.0 h1:Z2iHWqGXH00XYgqDmNgQbIBxf3wrNq0F3feEy0ainaU=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/stolostron/go-log-utils v0.1.1 h1:T48GyfuGpn2+6817FQVec1CyxGf0ibuVhoBiz9SeCec=
 github.com/stolostron/go-log-utils v0.1.1/go.mod h1:2Uc5mbuLvSFpoXFFEKRTEFOlR7nqGVMu9mbU+FIttTI=
@@ -755,6 +779,7 @@ golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLdyRGr576XBO4/greRjx4P4O3yc=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
+golang.org/x/net v0.0.0-20210421230115-4e50805a0758/go.mod h1:72T/g9IO56b78aLF+1Kcs5dz7/ng1VjMUvfKvpfy+jM=
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210825183410-e898025ed96a/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
@@ -778,8 +803,9 @@ golang.org/x/oauth2 v0.0.0-20210313182246-cd4f82c27b84/go.mod h1:KelEdhl1UZF7XfJ
 golang.org/x/oauth2 v0.0.0-20210402161424-2e8d93401602/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
-golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b h1:clP8eMhB30EHdc0bd2Twtq6kgU7yl5ub2cQLSdrv1Dg=
 golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
+golang.org/x/oauth2 v0.0.0-20220309155454-6242fa91716a h1:qfl7ob3DIEs3Ml9oLuPwY2N04gymzAW04WsUQHIClgM=
+golang.org/x/oauth2 v0.0.0-20220309155454-6242fa91716a/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -855,6 +881,7 @@ golang.org/x/sys v0.0.0-20210315160823-c6e025ad8005/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210420072515-93ed5bcd2bfe/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -880,8 +907,8 @@ golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
-golang.org/x/time v0.0.0-20220210224613-90d013bbcef8 h1:vVKdlvoWBphwdxWKrFZEuM0kGgGLxUOYcY4U/2Vjg44=
-golang.org/x/time v0.0.0-20220210224613-90d013bbcef8/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.0.0-20220224211638-0e9765cccd65 h1:M73Iuj3xbbb9Uk1DYhzydthsj6oOd6l9bpuFcNoUvTs=
+golang.org/x/time v0.0.0-20220224211638-0e9765cccd65/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20181011042414-1f849cf54d09/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20181030221726-6c7e314b6563/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
@@ -1031,6 +1058,8 @@ google.golang.org/genproto v0.0.0-20210319143718-93e7006c17a6/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20210402141018-6c239bbf2bb1/go.mod h1:9lPAdzaEmUacj36I+k7YKbEc5CXzPIeORRgDAUOu28A=
 google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c/go.mod h1:UODoCrxHCcBojKKwX1terBiRUaqAsFqJiF615XL43r0=
 google.golang.org/genproto v0.0.0-20210831024726-fe130286e0e2/go.mod h1:eFjDcFEctNawg4eG61bRv87N7iHBWyVhJu7u1kqDUXY=
+google.golang.org/genproto v0.0.0-20220407144326-9054f6ed7bac h1:qSNTkEN+L2mvWcLgJOR+8bdHX9rN/IdU3A1Ghpfb1Rg=
+google.golang.org/genproto v0.0.0-20220407144326-9054f6ed7bac/go.mod h1:8w6bsBMX6yCPbAVTeqQHvzxW0EIFigd5lZyahWgyfDo=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
@@ -1054,6 +1083,7 @@ google.golang.org/grpc v1.36.1/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAG
 google.golang.org/grpc v1.37.0/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQdJfM=
 google.golang.org/grpc v1.38.0/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQdJfM=
 google.golang.org/grpc v1.40.0/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9KAK34=
+google.golang.org/grpc v1.45.0/go.mod h1:lN7owxKUQEqMfSyQikvvk5tf/6zMPsrK+ONuO11+0rQ=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=
@@ -1067,6 +1097,7 @@ google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlba
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=
 google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
@@ -1183,8 +1214,8 @@ open-cluster-management.io/addon-framework v0.3.0 h1:tO1zW0yfYrH/bzsM34SH3c6GTa/
 open-cluster-management.io/addon-framework v0.3.0/go.mod h1:8QG1fHwPCEdyRrzY2Jji+qhMmJl+/HzTpuSDVmeG+7s=
 open-cluster-management.io/api v0.6.1-0.20220208144021-3297cac74dc5 h1:0Zn4+5qfXTHCjoa7pg8+fI/Gebr4bQDHWR+d1XPa47c=
 open-cluster-management.io/api v0.6.1-0.20220208144021-3297cac74dc5/go.mod h1:0IUTh8J+p4pv1THh1r9oO0luX9Z1FLDEAmvzW09qC0o=
-open-cluster-management.io/governance-policy-propagator v0.8.1-0.20221014182333-d078c8d17ca7 h1:0zaI0xkaUYa1Bzg84YVIGw3sp/jnKzeNLNve7nznWzY=
-open-cluster-management.io/governance-policy-propagator v0.8.1-0.20221014182333-d078c8d17ca7/go.mod h1:qANM1Ww0i7fN90ZDsN9CmPWyRq5kL5ZhuFpBG4MzzDY=
+open-cluster-management.io/governance-policy-propagator v0.10.0 h1:OJx7hWJPl1aCh+DGs8QKnvRte75KglmWXZJsBRjXQ6c=
+open-cluster-management.io/governance-policy-propagator v0.10.0/go.mod h1:5FV0Wd7QztYtb96a6GLxcNxVZoLdeOhyQ/DCzRs2w7A=
 open-cluster-management.io/multicloud-operators-subscription v0.8.0 h1:0YRrUErVU6K6xwExGNaCMF//FOfJT6XyeHAvSbZNEiY=
 open-cluster-management.io/multicloud-operators-subscription v0.8.0/go.mod h1:R83lMSoaMfs3T1Z3ApRjfioA9AgPMzam+CS6XbO5FjU=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=

--- a/main.go
+++ b/main.go
@@ -17,11 +17,11 @@ import (
 	"sync"
 
 	"github.com/go-logr/zapr"
+	gktemplatesv1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1"
+	gktemplatesv1beta1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1beta1"
 	"github.com/spf13/pflag"
 	"github.com/stolostron/go-log-utils/zaputil"
 	depclient "github.com/stolostron/kubernetes-dependency-watches/client"
-
-	// to ensure that exec-entrypoint and run can make use of them.
 	v1 "k8s.io/api/core/v1"
 	extensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	extensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
@@ -51,6 +51,7 @@ import (
 	"open-cluster-management.io/governance-policy-framework-addon/controllers/specsync"
 	"open-cluster-management.io/governance-policy-framework-addon/controllers/statussync"
 	"open-cluster-management.io/governance-policy-framework-addon/controllers/templatesync"
+	"open-cluster-management.io/governance-policy-framework-addon/controllers/utils"
 	"open-cluster-management.io/governance-policy-framework-addon/tool"
 	"open-cluster-management.io/governance-policy-framework-addon/version"
 )
@@ -79,6 +80,8 @@ func init() {
 	utilruntime.Must(policiesv1.AddToScheme(eventsScheme))
 	utilruntime.Must(extensionsv1.AddToScheme(scheme))
 	utilruntime.Must(extensionsv1beta1.AddToScheme(scheme))
+	utilruntime.Must(gktemplatesv1.AddToScheme(scheme))
+	utilruntime.Must(gktemplatesv1beta1.AddToScheme(scheme))
 }
 
 func main() {
@@ -336,7 +339,7 @@ func getManager(
 
 	hubRecorder := eventBroadcaster.NewRecorder(eventsScheme, v1.EventSource{Component: statussync.ControllerName})
 
-	crdLabelSelector := labels.SelectorFromSet(map[string]string{templatesync.PolicyTypeLabel: "template"})
+	crdLabelSelector := labels.SelectorFromSet(map[string]string{utils.PolicyTypeLabel: "template"})
 
 	options.LeaderElectionID = "governance-policy-framework-addon.open-cluster-management.io"
 	options.HealthProbeBindAddress = healthAddr

--- a/test/e2e/case10_error_test.go
+++ b/test/e2e/case10_error_test.go
@@ -198,7 +198,7 @@ var _ = Describe("Test error handling", func() {
 			_, found, _ := unstructured.NestedString(cfgPolicy.Object, "status", "compliant")
 
 			return found
-		}, defaultTimeoutSeconds, 1).Should(BeFalse())
+		}, defaultTimeoutSeconds*2, 1).Should(BeFalse())
 	})
 	It("should throw a noncompliance event if a non-configurationpolicy uses a hub template", func() {
 		By("Deploying a test policy CRD")

--- a/test/e2e/case12_ordering_test.go
+++ b/test/e2e/case12_ordering_test.go
@@ -54,6 +54,12 @@ var _ = Describe("Test dependency logic in template sync", Ordered, func() {
 		})
 	}
 
+	AfterEach(func() {
+		By("clean up all events")
+		_, err := kubectlManaged("delete", "events", "-n", clusterNamespace, "--all")
+		Expect(err).Should(BeNil())
+	})
+
 	It("Should set to compliant when dep status is compliant", func() {
 		By("Creating a dep on hub cluster in ns:" + clusterNamespaceOnHub)
 		hubPolicyApplyAndDeferCleanup(case12DepYaml, case12DepName)
@@ -102,7 +108,7 @@ var _ = Describe("Test dependency logic in template sync", Ordered, func() {
 		Eventually(checkCompliance(case12DepName), defaultTimeoutSeconds, 1).Should(Equal("NonCompliant"))
 
 		By("Checking if policy status is pending")
-		Eventually(checkCompliance(case12PolicyName), defaultTimeoutSeconds, 1).Should(Equal("Pending"))
+		Eventually(checkCompliance(case12PolicyName), defaultTimeoutSeconds*2, 1).Should(Equal("Pending"))
 	})
 	It("Should set to Compliant when dep status is NonCompliant and ignorePending is true", func() {
 		By("Creating a dep on hub cluster in ns:" + clusterNamespaceOnHub)
@@ -123,7 +129,8 @@ var _ = Describe("Test dependency logic in template sync", Ordered, func() {
 		Eventually(checkCompliance(case12DepName), defaultTimeoutSeconds, 1).Should(Equal("NonCompliant"))
 
 		By("Checking if policy status is pending")
-		Eventually(checkCompliance(case12PolicyIgnorePendingName), defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
+		Eventually(checkCompliance(case12PolicyIgnorePendingName),
+			defaultTimeoutSeconds*2, 1).Should(Equal("Compliant"))
 	})
 	It("Should set to Compliant when dep status is resolved", func() {
 		By("Creating a dep on hub cluster in ns:" + clusterNamespaceOnHub)
@@ -144,7 +151,7 @@ var _ = Describe("Test dependency logic in template sync", Ordered, func() {
 		Eventually(checkCompliance(case12DepName), defaultTimeoutSeconds, 1).Should(Equal("NonCompliant"))
 
 		By("Checking if policy status is pending")
-		Eventually(checkCompliance(case12PolicyName), defaultTimeoutSeconds, 1).Should(Equal("Pending"))
+		Eventually(checkCompliance(case12PolicyName), defaultTimeoutSeconds*2, 1).Should(Equal("Pending"))
 
 		By("Generating a compliant event on the dependency")
 		generateEventOnPolicy(
@@ -172,7 +179,7 @@ var _ = Describe("Test dependency logic in template sync", Ordered, func() {
 		hubPolicyApplyAndDeferCleanup(case12PolicyYamlInvalid, case12PolicyNameInvalid)
 
 		By("Checking if policy status is pending")
-		Eventually(checkCompliance(case12PolicyNameInvalid), defaultTimeoutSeconds, 1).Should(Equal("Pending"))
+		Eventually(checkCompliance(case12PolicyNameInvalid), defaultTimeoutSeconds*2, 1).Should(Equal("Pending"))
 	})
 	It("Should remove template if dependency changes", func() {
 		By("Creating a dep on hub cluster in ns:" + clusterNamespaceOnHub)
@@ -215,7 +222,7 @@ var _ = Describe("Test dependency logic in template sync", Ordered, func() {
 		Eventually(checkCompliance(case12DepName), defaultTimeoutSeconds, 1).Should(Equal("NonCompliant"))
 
 		By("Checking if policy status is pending")
-		Eventually(checkCompliance(case12PolicyName), defaultTimeoutSeconds, 1).Should(Equal("Pending"))
+		Eventually(checkCompliance(case12PolicyName), defaultTimeoutSeconds*2, 1).Should(Equal("Pending"))
 	})
 	It("Should process extra dependencies properly", func() {
 		By("Creating a policy on hub cluster in ns:" + clusterNamespaceOnHub)
@@ -258,7 +265,7 @@ var _ = Describe("Test dependency logic in template sync", Ordered, func() {
 		)
 
 		By("Checking if policy status is pending")
-		Eventually(checkCompliance(case12ExtraDepsPolicyName), defaultTimeoutSeconds, 1).Should(Equal("Pending"))
+		Eventually(checkCompliance(case12ExtraDepsPolicyName), defaultTimeoutSeconds*2, 1).Should(Equal("Pending"))
 	})
 	It("Should handle policies with multiple templates (with different dependencies) properly", func() {
 		By("Creating a policy on hub cluster in ns:" + clusterNamespaceOnHub)

--- a/test/e2e/case15_template_cleanup_test.go
+++ b/test/e2e/case15_template_cleanup_test.go
@@ -99,7 +99,7 @@ var _ = Describe("Test template sync", func() {
 			clusterNamespace, true, defaultTimeoutSeconds)
 		Expect(cfgplc).NotTo(BeNil())
 		cfgplc = utils.GetWithTimeout(clientManagedDynamic, gvrConfigurationPolicy, case15ConfigPolicyRenamed,
-			clusterNamespace, false, defaultTimeoutSeconds)
+			clusterNamespace, false, defaultTimeoutSeconds*2)
 		Expect(cfgplc).To(BeNil())
 	})
 })

--- a/test/e2e/case17_gatekeeper_sync_test.go
+++ b/test/e2e/case17_gatekeeper_sync_test.go
@@ -1,0 +1,144 @@
+// Copyright (c) 2020 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package e2e
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	propagatorutils "open-cluster-management.io/governance-policy-propagator/test/utils"
+
+	"open-cluster-management.io/governance-policy-framework-addon/test/utils"
+)
+
+var _ = Describe("Test Gatekeeper ConstraintTemplate sync", Ordered, Label("skip-minimum"), func() {
+	const (
+		caseNumber               string = "case17"
+		policyName               string = caseNumber + "-gk-policy"
+		policyName2              string = caseNumber + "-gk-policy-2"
+		yamlBasePath             string = "../resources/" + caseNumber + "_gatekeeper_sync/"
+		policyYaml               string = yamlBasePath + policyName + ".yaml"
+		policyYaml2              string = yamlBasePath + policyName2 + ".yaml"
+		gkConstraintTemplateName string = caseNumber + "k8srequiredlabels"
+		gkConstraintTemplateYaml string = yamlBasePath + gkConstraintTemplateName + ".yaml"
+		gkConstraintName         string = caseNumber + "-gk-constraint"
+		gkConstraintYaml         string = yamlBasePath + gkConstraintName + ".yaml"
+		gkConstraintName2        string = caseNumber + "-gk-constraint-2"
+		gkConstraintYaml2        string = yamlBasePath + gkConstraintName2 + ".yaml"
+	)
+	gvrConstraint := schema.GroupVersionResource{
+		Group:    gvConstraintGroup,
+		Version:  "v1beta1",
+		Resource: caseNumber + "k8srequiredlabels",
+	}
+	BeforeAll(func() {
+		DeployGatekeeper()
+	})
+	AfterAll(func() {
+		for _, pName := range []string{policyName, policyName2} {
+			By("Deleting policy " + pName + " on the hub in ns:" + clusterNamespaceOnHub)
+			err := clientHubDynamic.Resource(gvrPolicy).Namespace(clusterNamespaceOnHub).Delete(
+				context.TODO(), pName, metav1.DeleteOptions{},
+			)
+			if !errors.IsNotFound(err) {
+				Expect(err).To(BeNil())
+			}
+			By("Cleaning up the events from policy " + pName)
+			_, err = kubectlManaged("delete", "events", "-n", clusterNamespace, "--ignore-not-found",
+				"--field-selector=involvedObject.name="+pName,
+			)
+			Expect(err).To(BeNil())
+		}
+		opt := metav1.ListOptions{}
+		propagatorutils.ListWithTimeout(clientManagedDynamic, gvrPolicy, opt, 0, true, defaultTimeoutSeconds)
+
+		By("Deleting Gatekeeper " + utils.GkVersion + " from the managed cluster")
+		_, err := kubectlManaged("delete", "-f", utils.GkDeployment)
+		Expect(err).Should(BeNil())
+	})
+	It("should create the policy on the managed cluster", func() {
+		By("Creating policy " + policyName + " on the hub in ns:" + clusterNamespaceOnHub)
+		_, err := kubectlHub("apply", "-f", policyYaml, "-n", clusterNamespaceOnHub)
+		Expect(err).Should(BeNil())
+		plc := propagatorutils.GetWithTimeout(clientManagedDynamic, gvrPolicy, policyName, clusterNamespace, true,
+			defaultTimeoutSeconds)
+		Expect(plc).NotTo(BeNil())
+		By("Creating policy " + policyName2 + " on the hub in ns:" + clusterNamespaceOnHub)
+		_, err = kubectlHub("apply", "-f", policyYaml2, "-n", clusterNamespaceOnHub)
+		Expect(err).Should(BeNil())
+		plc = propagatorutils.GetWithTimeout(clientManagedDynamic, gvrPolicy, policyName, clusterNamespace, true,
+			defaultTimeoutSeconds)
+		Expect(plc).NotTo(BeNil())
+	})
+	It("should create Gatekeeper constraints on the managed cluster", func() {
+		By("Checking for the synced ConstraintTemplate " + gkConstraintTemplateName)
+		expectedConstraintTemplate := propagatorutils.ParseYaml(gkConstraintTemplateYaml)
+		Eventually(func() interface{} {
+			trustedPlc := propagatorutils.GetWithTimeout(clientManagedDynamic, gvrConstraintTemplate,
+				gkConstraintTemplateName, "", true, defaultTimeoutSeconds)
+
+			return trustedPlc.Object["spec"]
+		}, defaultTimeoutSeconds, 1).Should(propagatorutils.SemanticEqual(expectedConstraintTemplate.Object["spec"]))
+		By("Checking for the synced Constraint " + gkConstraintName)
+		expectedConstraint := propagatorutils.ParseYaml(gkConstraintYaml)
+		Eventually(func() interface{} {
+			trustedPlc := propagatorutils.GetWithTimeout(clientManagedDynamic, gvrConstraint,
+				gkConstraintName, "", true, defaultTimeoutSeconds)
+
+			return trustedPlc.Object["spec"]
+		}, defaultTimeoutSeconds, 1).Should(propagatorutils.SemanticEqual(expectedConstraint.Object["spec"]))
+		By("Checking for the synced Constraint " + gkConstraintName2)
+		expectedConstraint2 := propagatorutils.ParseYaml(gkConstraintYaml2)
+		Eventually(func() interface{} {
+			trustedPlc := propagatorutils.GetWithTimeout(clientManagedDynamic, gvrConstraint,
+				gkConstraintName2, "", true, defaultTimeoutSeconds)
+
+			return trustedPlc.Object["spec"]
+		}, defaultTimeoutSeconds, 1).Should(propagatorutils.SemanticEqual(expectedConstraint2.Object["spec"]))
+	})
+	It("should set status for the ConstraintTemplate to Compliant", func() {
+		By("Checking if policy status is compliant for the ConstraintTemplate")
+		managedPlc := propagatorutils.GetWithTimeout(clientManagedDynamic, gvrPolicy, policyName, clusterNamespace,
+			true, defaultTimeoutSeconds)
+		Expect(managedPlc).NotTo(BeNil())
+
+		Eventually(func() string {
+			var compliance string
+			detailsSlice, found, err := unstructured.NestedSlice(managedPlc.Object, "status", "details")
+			if found {
+				compliance, _, _ = unstructured.NestedString(detailsSlice[0].(map[string]interface{}), "compliant")
+			} else if err != nil {
+				GinkgoWriter.Printf("Failed to retrieve compliance: %s\n", err)
+			}
+
+			return compliance
+		}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
+	})
+	It("should delete template policy on managed cluster", func() {
+		By("Deleting parent policies")
+		_, err := kubectlHub("delete", "-f", policyYaml, "-n", clusterNamespaceOnHub)
+		Expect(err).Should(BeNil())
+		_, err = kubectlHub("delete", "-f", policyYaml2, "-n", clusterNamespaceOnHub)
+		Expect(err).Should(BeNil())
+		opt := metav1.ListOptions{}
+		propagatorutils.ListWithTimeout(clientManagedDynamic, gvrPolicy, opt, 0, true, defaultTimeoutSeconds)
+		By("Checking for the existence of ConstraintTemplate " + gkConstraintTemplateName)
+		propagatorutils.GetWithTimeout(clientManagedDynamic, gvrConstraintTemplate, gkConstraintTemplateName,
+			"", false, defaultTimeoutSeconds,
+		)
+		By("Checking for the existence of Constraint " + gkConstraintName)
+		propagatorutils.GetWithTimeout(clientManagedDynamic, gvrConstraint, gkConstraintName,
+			"", false, defaultTimeoutSeconds,
+		)
+		By("Checking for the existence of Constraint " + gkConstraintName2)
+		propagatorutils.GetWithTimeout(clientManagedDynamic, gvrConstraint, gkConstraintName2,
+			"", false, defaultTimeoutSeconds,
+		)
+	})
+})

--- a/test/e2e/case2_status_sync_test.go
+++ b/test/e2e/case2_status_sync_test.go
@@ -201,7 +201,7 @@ var _ = Describe("Test status sync", func() {
 			"Normal",
 			"policy: managed/case2-test-policy-configurationpolicy",
 			"Compliant; No violation assert")
-		Eventually(func() interface{} {
+		Eventually(func(g Gomega) interface{} {
 			managedPlc = utils.GetWithTimeout(
 				clientManagedDynamic,
 				gvrPolicy,
@@ -210,7 +210,14 @@ var _ = Describe("Test status sync", func() {
 				true,
 				defaultTimeoutSeconds)
 			err := runtime.DefaultUnstructuredConverter.FromUnstructured(managedPlc.Object, &plc)
-			Expect(err).To(BeNil())
+			g.Expect(err).To(BeNil())
+
+			if len(plc.Status.Details) == 0 {
+				return "status.details[] is empty"
+			}
+			if len(plc.Status.Details[0].History) == 0 {
+				return "status.details[0].history[] is empty"
+			}
 
 			return plc.Status.Details[0].History[0].Message
 		}, defaultTimeoutSeconds, 1).Should(Equal("Compliant; No violation assert"))
@@ -228,7 +235,7 @@ var _ = Describe("Test status sync", func() {
 			"Warning",
 			"policy: managed/case2-test-policy-configurationpolicy",
 			"NonCompliant; Violation assert")
-		Eventually(func() interface{} {
+		Eventually(func(g Gomega) interface{} {
 			managedPlc = utils.GetWithTimeout(
 				clientManagedDynamic,
 				gvrPolicy,
@@ -237,7 +244,7 @@ var _ = Describe("Test status sync", func() {
 				true,
 				defaultTimeoutSeconds)
 			err := runtime.DefaultUnstructuredConverter.FromUnstructured(managedPlc.Object, &plc)
-			Expect(err).To(BeNil())
+			g.Expect(err).To(BeNil())
 
 			return plc.Status.Details[0].History[0].Message
 		}, defaultTimeoutSeconds, 1).Should(Equal("NonCompliant; Violation assert"))

--- a/test/e2e/case3_multiple_templates_test.go
+++ b/test/e2e/case3_multiple_templates_test.go
@@ -98,7 +98,7 @@ var _ = Describe("Test status sync with multiple templates", func() {
 			"Compliant; there is no violation")
 		By("Checking if template: case3-test-policy-configurationpolicy1 status is compliant")
 		var plc *policiesv1.Policy
-		Eventually(func() interface{} {
+		Eventually(func(g Gomega) interface{} {
 			managedPlc = utils.GetWithTimeout(
 				clientManagedDynamic,
 				gvrPolicy,
@@ -107,11 +107,11 @@ var _ = Describe("Test status sync with multiple templates", func() {
 				true,
 				defaultTimeoutSeconds)
 			err := runtime.DefaultUnstructuredConverter.FromUnstructured(managedPlc.Object, &plc)
-			Expect(err).To(BeNil())
+			g.Expect(err).To(BeNil())
 			if len(plc.Status.Details) < 1 {
 				return ""
 			}
-			Expect(plc.Status.Details[0].TemplateMeta.GetName()).To(Equal("case3-test-policy-configurationpolicy1"))
+			g.Expect(plc.Status.Details[0].TemplateMeta.GetName()).To(Equal("case3-test-policy-configurationpolicy1"))
 
 			return plc.Status.Details[0].ComplianceState
 		}, defaultTimeoutSeconds, 1).Should(Equal(policiesv1.Compliant))
@@ -157,7 +157,7 @@ var _ = Describe("Test status sync with multiple templates", func() {
 			"Compliant; there is no violation")
 		By("Checking if template: case3-test-policy-configurationpolicy2 status is compliant")
 		var plc *policiesv1.Policy
-		Eventually(func() interface{} {
+		Eventually(func(g Gomega) interface{} {
 			managedPlc = utils.GetWithTimeout(
 				clientManagedDynamic,
 				gvrPolicy,
@@ -166,11 +166,11 @@ var _ = Describe("Test status sync with multiple templates", func() {
 				true,
 				defaultTimeoutSeconds)
 			err := runtime.DefaultUnstructuredConverter.FromUnstructured(managedPlc.Object, &plc)
-			Expect(err).To(BeNil())
+			g.Expect(err).To(BeNil())
 			if len(plc.Status.Details) < 2 {
 				return ""
 			}
-			Expect(plc.Status.Details[1].TemplateMeta.GetName()).To(Equal("case3-test-policy-configurationpolicy2"))
+			g.Expect(plc.Status.Details[1].TemplateMeta.GetName()).To(Equal("case3-test-policy-configurationpolicy2"))
 
 			return plc.Status.Details[1].ComplianceState
 		}, defaultTimeoutSeconds, 1).Should(Equal(policiesv1.Compliant))
@@ -436,7 +436,7 @@ var _ = Describe("Test status sync with multiple templates", func() {
 		Expect(managedPlc).NotTo(BeNil())
 		By("Checking if policy status of template1 has been removed")
 		var plc *policiesv1.Policy
-		Eventually(func() interface{} {
+		Eventually(func(g Gomega) interface{} {
 			managedPlc = utils.GetWithTimeout(
 				clientManagedDynamic,
 				gvrPolicy,
@@ -445,7 +445,7 @@ var _ = Describe("Test status sync with multiple templates", func() {
 				true,
 				defaultTimeoutSeconds)
 			err := runtime.DefaultUnstructuredConverter.FromUnstructured(managedPlc.Object, &plc)
-			Expect(err).To(BeNil())
+			g.Expect(err).To(BeNil())
 
 			return len(plc.Status.Details)
 		}, defaultTimeoutSeconds, 1).Should(Equal(1))
@@ -521,7 +521,7 @@ var _ = Describe("Test status sync with multiple templates", func() {
 		Expect(managedPlc).NotTo(BeNil())
 		By("Checking if policy status of template2 has been removed")
 		var plc *policiesv1.Policy
-		Eventually(func() interface{} {
+		Eventually(func(g Gomega) interface{} {
 			managedPlc = utils.GetWithTimeout(
 				clientManagedDynamic,
 				gvrPolicy,
@@ -530,7 +530,7 @@ var _ = Describe("Test status sync with multiple templates", func() {
 				true,
 				defaultTimeoutSeconds)
 			err := runtime.DefaultUnstructuredConverter.FromUnstructured(managedPlc.Object, &plc)
-			Expect(err).To(BeNil())
+			g.Expect(err).To(BeNil())
 
 			return len(plc.Status.Details)
 		}, defaultTimeoutSeconds, 1).Should(Equal(1))

--- a/test/e2e/case4_status_merge_test.go
+++ b/test/e2e/case4_status_merge_test.go
@@ -94,7 +94,7 @@ var _ = Describe("Test status sync with multiple templates", func() {
 			return getCompliant(managedPlc)
 		}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
 		// Wait for slow events to show up, otherwise the delete might not get all of them.
-		time.Sleep(10 * time.Second)
+		time.Sleep(15 * time.Second)
 		By("Delete events in ns:" + clusterNamespace)
 		_, err := kubectlManaged(
 			"delete",
@@ -124,7 +124,7 @@ var _ = Describe("Test status sync with multiple templates", func() {
 			"Compliant; No violation detected")
 		By("Checking if history size = 3")
 		var plc *policiesv1.Policy
-		Eventually(func() interface{} {
+		Eventually(func(g Gomega) interface{} {
 			managedPlc = utils.GetWithTimeout(
 				clientManagedDynamic,
 				gvrPolicy,
@@ -133,8 +133,8 @@ var _ = Describe("Test status sync with multiple templates", func() {
 				true,
 				defaultTimeoutSeconds)
 			err := runtime.DefaultUnstructuredConverter.FromUnstructured(managedPlc.Object, &plc)
-			Expect(err).To(BeNil())
-			Expect(plc.Status.Details[0].TemplateMeta.GetName()).To(Equal("case4-test-policy-configurationpolicy"))
+			g.Expect(err).To(BeNil())
+			g.Expect(plc.Status.Details[0].TemplateMeta.GetName()).To(Equal("case4-test-policy-configurationpolicy"))
 
 			return len(plc.Status.Details[0].History)
 		}, defaultTimeoutSeconds, 1).Should(Equal(3))

--- a/test/e2e/case6_event_msg_test.go
+++ b/test/e2e/case6_event_msg_test.go
@@ -81,7 +81,7 @@ var _ = Describe("Test event message handling", func() {
 			"(combined from similar events): NonCompliant; Violation detected")
 		By("Checking if violation message contains the prefix")
 		var plc *policiesv1.Policy
-		Eventually(func() interface{} {
+		Eventually(func(g Gomega) interface{} {
 			managedPlc = utils.GetWithTimeout(
 				clientManagedDynamic,
 				gvrPolicy,
@@ -90,14 +90,14 @@ var _ = Describe("Test event message handling", func() {
 				true,
 				defaultTimeoutSeconds)
 			err := runtime.DefaultUnstructuredConverter.FromUnstructured(managedPlc.Object, &plc)
-			Expect(err).To(BeNil())
+			g.Expect(err).To(BeNil())
 			if len(plc.Status.Details) < 1 {
 				return 0
 			}
 
 			return len(plc.Status.Details[0].History)
 		}, defaultTimeoutSeconds, 1).Should(Equal(1))
-		Eventually(func() interface{} {
+		Eventually(func(g Gomega) interface{} {
 			managedPlc = utils.GetWithTimeout(
 				clientManagedDynamic,
 				gvrPolicy,
@@ -106,7 +106,7 @@ var _ = Describe("Test event message handling", func() {
 				true,
 				defaultTimeoutSeconds)
 			err := runtime.DefaultUnstructuredConverter.FromUnstructured(managedPlc.Object, &plc)
-			Expect(err).To(BeNil())
+			g.Expect(err).To(BeNil())
 			if len(plc.Status.Details) < 1 {
 				return ""
 			}
@@ -133,7 +133,7 @@ var _ = Describe("Test event message handling", func() {
 			"(combined from similar events): Compliant; no violation detected")
 		By("Checking if violation message contains the prefix")
 		var plc *policiesv1.Policy
-		Eventually(func() interface{} {
+		Eventually(func(g Gomega) interface{} {
 			managedPlc = utils.GetWithTimeout(
 				clientManagedDynamic,
 				gvrPolicy,
@@ -142,14 +142,14 @@ var _ = Describe("Test event message handling", func() {
 				true,
 				defaultTimeoutSeconds)
 			err := runtime.DefaultUnstructuredConverter.FromUnstructured(managedPlc.Object, &plc)
-			Expect(err).To(BeNil())
+			g.Expect(err).To(BeNil())
 			if len(plc.Status.Details) < 1 {
 				return 0
 			}
 
 			return len(plc.Status.Details[0].History)
 		}, defaultTimeoutSeconds, 1).Should(Equal(1))
-		Eventually(func() interface{} {
+		Eventually(func(g Gomega) interface{} {
 			managedPlc = utils.GetWithTimeout(
 				clientManagedDynamic,
 				gvrPolicy,
@@ -158,7 +158,7 @@ var _ = Describe("Test event message handling", func() {
 				true,
 				defaultTimeoutSeconds)
 			err := runtime.DefaultUnstructuredConverter.FromUnstructured(managedPlc.Object, &plc)
-			Expect(err).To(BeNil())
+			g.Expect(err).To(BeNil())
 			if len(plc.Status.Details) < 1 {
 				return ""
 			}
@@ -185,7 +185,7 @@ var _ = Describe("Test event message handling", func() {
 			"NonCompliant")
 		By("Checking if violation message is in history")
 		var plc *policiesv1.Policy
-		Eventually(func() interface{} {
+		Eventually(func(g Gomega) interface{} {
 			managedPlc = utils.GetWithTimeout(
 				clientManagedDynamic,
 				gvrPolicy,
@@ -194,14 +194,14 @@ var _ = Describe("Test event message handling", func() {
 				true,
 				defaultTimeoutSeconds)
 			err := runtime.DefaultUnstructuredConverter.FromUnstructured(managedPlc.Object, &plc)
-			Expect(err).To(BeNil())
+			g.Expect(err).To(BeNil())
 			if len(plc.Status.Details) < 1 {
 				return 0
 			}
 
 			return len(plc.Status.Details[0].History)
 		}, defaultTimeoutSeconds, 1).Should(Equal(1))
-		Eventually(func() interface{} {
+		Eventually(func(g Gomega) interface{} {
 			managedPlc = utils.GetWithTimeout(
 				clientManagedDynamic,
 				gvrPolicy,
@@ -210,7 +210,7 @@ var _ = Describe("Test event message handling", func() {
 				true,
 				defaultTimeoutSeconds)
 			err := runtime.DefaultUnstructuredConverter.FromUnstructured(managedPlc.Object, &plc)
-			Expect(err).To(BeNil())
+			g.Expect(err).To(BeNil())
 			if len(plc.Status.Details) < 1 {
 				return ""
 			}
@@ -237,7 +237,7 @@ var _ = Describe("Test event message handling", func() {
 			"Compliant")
 		By("Checking if violation message is in history")
 		var plc *policiesv1.Policy
-		Eventually(func() interface{} {
+		Eventually(func(g Gomega) interface{} {
 			managedPlc = utils.GetWithTimeout(
 				clientManagedDynamic,
 				gvrPolicy,
@@ -246,14 +246,14 @@ var _ = Describe("Test event message handling", func() {
 				true,
 				defaultTimeoutSeconds)
 			err := runtime.DefaultUnstructuredConverter.FromUnstructured(managedPlc.Object, &plc)
-			Expect(err).To(BeNil())
+			g.Expect(err).To(BeNil())
 			if len(plc.Status.Details) < 1 {
 				return 0
 			}
 
 			return len(plc.Status.Details[0].History)
 		}, defaultTimeoutSeconds, 1).Should(Equal(1))
-		Eventually(func() interface{} {
+		Eventually(func(g Gomega) interface{} {
 			managedPlc = utils.GetWithTimeout(
 				clientManagedDynamic,
 				gvrPolicy,
@@ -262,7 +262,7 @@ var _ = Describe("Test event message handling", func() {
 				true,
 				defaultTimeoutSeconds)
 			err := runtime.DefaultUnstructuredConverter.FromUnstructured(managedPlc.Object, &plc)
-			Expect(err).To(BeNil())
+			g.Expect(err).To(BeNil())
 			if len(plc.Status.Details) < 1 {
 				return ""
 			}

--- a/test/resources/case10_template_sync_error_test/mock-crd.yaml
+++ b/test/resources/case10_template_sync_error_test/mock-crd.yaml
@@ -1,0 +1,30 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    policy.open-cluster-management.io/policy-type: template
+  name: mockpolicies.policy.open-cluster-management.io
+spec:
+  group: policy.open-cluster-management.io
+  names:
+    kind: MockPolicy
+    listKind: MockPolicyList
+    plural: mockpolicies
+    singular: mockpolicy
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object

--- a/test/resources/case10_template_sync_error_test/unsupported-object-error.yaml
+++ b/test/resources/case10_template_sync_error_test/unsupported-object-error.yaml
@@ -1,19 +1,17 @@
 apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
-  name: case10-bad-hubtemplate
+  name: case10-unsupported-object
   labels:
     policy.open-cluster-management.io/cluster-name: managed
     policy.open-cluster-management.io/cluster-namespace: managed
-    policy.open-cluster-management.io/root-policy: case10-bad-hubtemplate
+    policy.open-cluster-management.io/root-policy: case10-unsupported-object
 spec:
   remediationAction: inform
   disabled: false
   policy-templates:
     - objectDefinition:
-        apiVersion: policy.open-cluster-management.io/v1
-        kind: MockPolicy
+        apiVersion: apiextensions.k8s.io/v1
+        kind: CustomResourceDefinition
         metadata:
-          name: case10-bad-hubtemplate-policy
-        spec:
-          foo: 'I come from {{hub the land down under hub}}'
+          name: case10-unsupported-object

--- a/test/resources/case17_gatekeeper_sync/case17-gk-constraint-2.yaml
+++ b/test/resources/case17_gatekeeper_sync/case17-gk-constraint-2.yaml
@@ -1,5 +1,5 @@
 apiVersion: constraints.gatekeeper.sh/v1beta1
-kind: Case17K8sRequiredLabels
+kind: Case17ConstraintTemplate
 metadata:
   name: case17-gk-constraint-2
 spec:

--- a/test/resources/case17_gatekeeper_sync/case17-gk-constraint-2.yaml
+++ b/test/resources/case17_gatekeeper_sync/case17-gk-constraint-2.yaml
@@ -1,0 +1,14 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: Case17K8sRequiredLabels
+metadata:
+  name: case17-gk-constraint-2
+spec:
+  enforcementAction: warn
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Namespace"]
+  parameters:
+    message: "All namespaces must have a `super-duper` label"
+    labels:
+    - key: "super-duper"

--- a/test/resources/case17_gatekeeper_sync/case17-gk-constraint-extra.yaml
+++ b/test/resources/case17_gatekeeper_sync/case17-gk-constraint-extra.yaml
@@ -1,7 +1,7 @@
 apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: Case17ConstraintTemplate
 metadata:
-  name: case17-gk-constraint
+  name: case17-gk-constraint-extra
 spec:
   enforcementAction: warn
   match:
@@ -9,6 +9,6 @@ spec:
       - apiGroups: [""]
         kinds: ["Namespace"]
   parameters:
-    message: "All namespaces must have a `gatekeeper` label"
+    message: "All namespaces must have an `awesome` label"
     labels:
-    - key: "gatekeeper"
+    - key: "awesome"

--- a/test/resources/case17_gatekeeper_sync/case17-gk-constraint.yaml
+++ b/test/resources/case17_gatekeeper_sync/case17-gk-constraint.yaml
@@ -1,0 +1,14 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: Case17K8sRequiredLabels
+metadata:
+  name: case17-gk-constraint
+spec:
+  enforcementAction: warn
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Namespace"]
+  parameters:
+    message: "All namespaces must have a `gatekeeper` label"
+    labels:
+    - key: "gatekeeper"

--- a/test/resources/case17_gatekeeper_sync/case17-gk-policy-2.yaml
+++ b/test/resources/case17_gatekeeper_sync/case17-gk-policy-2.yaml
@@ -8,7 +8,7 @@ spec:
   policy-templates:
     - objectDefinition:
         apiVersion: constraints.gatekeeper.sh/v1beta1
-        kind: Case17K8sRequiredLabels
+        kind: Case17ConstraintTemplate
         metadata:
           name: case17-gk-constraint-2
         spec:

--- a/test/resources/case17_gatekeeper_sync/case17-gk-policy-2.yaml
+++ b/test/resources/case17_gatekeeper_sync/case17-gk-policy-2.yaml
@@ -1,0 +1,23 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: case17-gk-policy-2
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: constraints.gatekeeper.sh/v1beta1
+        kind: Case17K8sRequiredLabels
+        metadata:
+          name: case17-gk-constraint-2
+        spec:
+          enforcementAction: dryrun
+          match:
+            kinds:
+              - apiGroups: [""]
+                kinds: ["Namespace"]
+          parameters:
+            message: "All namespaces must have a `super-duper` label"
+            labels:
+            - key: "super-duper"

--- a/test/resources/case17_gatekeeper_sync/case17-gk-policy-extra.yaml
+++ b/test/resources/case17_gatekeeper_sync/case17-gk-policy-extra.yaml
@@ -1,0 +1,167 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: case17-gk-policy
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: templates.gatekeeper.sh/v1
+        kind: ConstraintTemplate
+        metadata:
+          name: case17constrainttemplate
+          annotations:
+            metadata.gatekeeper.sh/title: "Required Labels"
+            metadata.gatekeeper.sh/version: 1.0.0
+            description: >-
+              Requires resources to contain specified labels, with values matching provided regular expressions.
+        spec:
+          crd:
+            spec:
+              names:
+                kind: Case17ConstraintTemplate
+              validation:
+                legacySchema: false
+                openAPIV3Schema:
+                  type: object
+                  properties:
+                    message:
+                      type: string
+                    labels:
+                      type: array
+                      description: >-
+                        A list of labels and values the object must specify.
+                      items:
+                        type: object
+                        properties:
+                          key:
+                            type: string
+                            description: >-
+                              The required label.
+                          allowedRegex:
+                            type: string
+                            description: >-
+                              If specified, a regular expression the annotation's value must match. The value must
+                              contain at least one match for the regular expression.
+          targets:
+            - target: admission.k8s.gatekeeper.sh
+              rego: |
+                package k8srequiredlabels
+
+                get_message(parameters, _default) = msg {
+                  not parameters.message
+                  msg := _default
+                }
+
+                get_message(parameters, _default) = msg {
+                  msg := parameters.message
+                }
+
+                violation[{"msg": msg, "details": {"missing_labels": missing}}] {
+                  provided := {label | input.review.object.metadata.labels[label]}
+                  required := {label | label := input.parameters.labels[_].key}
+                  missing := required - provided
+                  count(missing) > 0
+                  def_msg := sprintf("you must provide labels: %v", [missing])
+                  msg := get_message(input.parameters, def_msg)
+                }
+
+                violation[{"msg": msg}] {
+                  value := input.review.object.metadata.labels[key]
+                  expected := input.parameters.labels[_]
+                  expected.key == key
+                  # do not match if allowedRegex is not defined, or is an empty string
+                  expected.allowedRegex != ""
+                  not re_match(expected.allowedRegex, value)
+                  def_msg := sprintf("Label <%v: %v> does not satisfy allowed regex: %v", [key, value, expected.allowedRegex])
+                  msg := get_message(input.parameters, def_msg)
+                }
+    - objectDefinition:
+        apiVersion: templates.gatekeeper.sh/v1
+        kind: ConstraintTemplate
+        metadata:
+          name: case17constrainttemplateextra
+          annotations:
+            metadata.gatekeeper.sh/title: "Required Annotations"
+            metadata.gatekeeper.sh/version: 1.0.0
+            description: >-
+              Requires resources to contain specified annotations, with values matching provided regular expressions.
+        spec:
+          crd:
+            spec:
+              names:
+                kind: Case17ConstraintTemplateExtra
+              validation:
+                openAPIV3Schema:
+                  type: object
+                  properties:
+                    message:
+                      type: string
+                    annotations:
+                      type: array
+                      description: >-
+                        A list of annotations and values the object must specify.
+                      items:
+                        type: object
+                        properties:
+                          key:
+                            type: string
+                            description: >-
+                              The required annotation.
+                          allowedRegex:
+                            type: string
+                            description: >-
+                              If specified, a regular expression the annotation's value must match. The value must
+                              contain at least one match for the regular expression.
+          targets:
+            - target: admission.k8s.gatekeeper.sh
+              rego: |
+                package k8srequiredannotations
+
+                violation[{"msg": msg, "details": {"missing_annotations": missing}}] {
+                    provided := {annotation | input.review.object.metadata.annotations[annotation]}
+                    required := {annotation | annotation := input.parameters.annotations[_].key}
+                    missing := required - provided
+                    count(missing) > 0
+                    msg := sprintf("you must provide annotation(s): %v", [missing])
+                }
+
+                violation[{"msg": msg}] {
+                  value := input.review.object.metadata.annotations[key]
+                  expected := input.parameters.annotations[_]
+                  expected.key == key
+                  expected.allowedRegex != ""
+                  not re_match(expected.allowedRegex, value)
+                  msg := sprintf("Annotation <%v: %v> does not satisfy allowed regex: %v", [key, value, expected.allowedRegex])
+                }
+    - objectDefinition:
+        apiVersion: constraints.gatekeeper.sh/v1beta1
+        kind: Case17ConstraintTemplate
+        metadata:
+          name: case17-gk-constraint
+        spec:
+          enforcementAction: dryrun
+          match:
+            kinds:
+              - apiGroups: [""]
+                kinds: ["Namespace"]
+          parameters:
+            message: "All namespaces must have a `gatekeeper` label"
+            labels:
+              - key: "gatekeeper"
+    - objectDefinition:
+        apiVersion: constraints.gatekeeper.sh/v1beta1
+        kind: Case17ConstraintTemplate
+        metadata:
+          name: case17-gk-constraint-extra
+        spec:
+          enforcementAction: dryrun
+          match:
+            kinds:
+              - apiGroups: [""]
+                kinds: ["Namespace"]
+          parameters:
+            message: "All namespaces must have an `awesome` label"
+            labels:
+              - key: "awesome"

--- a/test/resources/case17_gatekeeper_sync/case17-gk-policy.yaml
+++ b/test/resources/case17_gatekeeper_sync/case17-gk-policy.yaml
@@ -10,7 +10,7 @@ spec:
         apiVersion: templates.gatekeeper.sh/v1
         kind: ConstraintTemplate
         metadata:
-          name: case17k8srequiredlabels
+          name: case17constrainttemplate
           annotations:
             metadata.gatekeeper.sh/title: "Required Labels"
             metadata.gatekeeper.sh/version: 1.0.0
@@ -21,7 +21,7 @@ spec:
           crd:
             spec:
               names:
-                kind: Case17K8sRequiredLabels
+                kind: Case17ConstraintTemplate
               validation:
                 legacySchema: false
                 openAPIV3Schema:
@@ -79,10 +79,9 @@ spec:
                   def_msg := sprintf("Label <%v: %v> does not satisfy allowed regex: %v", [key, value, expected.allowedRegex])
                   msg := get_message(input.parameters, def_msg)
                 }
-
     - objectDefinition:
         apiVersion: constraints.gatekeeper.sh/v1beta1
-        kind: Case17K8sRequiredLabels
+        kind: Case17ConstraintTemplate
         metadata:
           name: case17-gk-constraint
         spec:

--- a/test/resources/case17_gatekeeper_sync/case17-gk-policy.yaml
+++ b/test/resources/case17_gatekeeper_sync/case17-gk-policy.yaml
@@ -1,0 +1,97 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: case17-gk-policy
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: templates.gatekeeper.sh/v1
+        kind: ConstraintTemplate
+        metadata:
+          name: case17k8srequiredlabels
+          annotations:
+            metadata.gatekeeper.sh/title: "Required Labels"
+            metadata.gatekeeper.sh/version: 1.0.0
+            description: >-
+              Requires resources to contain specified labels, with values matching
+              provided regular expressions.
+        spec:
+          crd:
+            spec:
+              names:
+                kind: Case17K8sRequiredLabels
+              validation:
+                legacySchema: false
+                openAPIV3Schema:
+                  type: object
+                  properties:
+                    message:
+                      type: string
+                    labels:
+                      type: array
+                      description: >-
+                        A list of labels and values the object must specify.
+                      items:
+                        type: object
+                        properties:
+                          key:
+                            type: string
+                            description: >-
+                              The required label.
+                          allowedRegex:
+                            type: string
+                            description: >-
+                              If specified, a regular expression the annotation's value
+                              must match. The value must contain at least one match for
+                              the regular expression.
+          targets:
+            - target: admission.k8s.gatekeeper.sh
+              rego: |
+                package k8srequiredlabels
+
+                get_message(parameters, _default) = msg {
+                  not parameters.message
+                  msg := _default
+                }
+
+                get_message(parameters, _default) = msg {
+                  msg := parameters.message
+                }
+
+                violation[{"msg": msg, "details": {"missing_labels": missing}}] {
+                  provided := {label | input.review.object.metadata.labels[label]}
+                  required := {label | label := input.parameters.labels[_].key}
+                  missing := required - provided
+                  count(missing) > 0
+                  def_msg := sprintf("you must provide labels: %v", [missing])
+                  msg := get_message(input.parameters, def_msg)
+                }
+
+                violation[{"msg": msg}] {
+                  value := input.review.object.metadata.labels[key]
+                  expected := input.parameters.labels[_]
+                  expected.key == key
+                  # do not match if allowedRegex is not defined, or is an empty string
+                  expected.allowedRegex != ""
+                  not re_match(expected.allowedRegex, value)
+                  def_msg := sprintf("Label <%v: %v> does not satisfy allowed regex: %v", [key, value, expected.allowedRegex])
+                  msg := get_message(input.parameters, def_msg)
+                }
+
+    - objectDefinition:
+        apiVersion: constraints.gatekeeper.sh/v1beta1
+        kind: Case17K8sRequiredLabels
+        metadata:
+          name: case17-gk-constraint
+        spec:
+          enforcementAction: dryrun
+          match:
+            kinds:
+              - apiGroups: [""]
+                kinds: ["Namespace"]
+          parameters:
+            message: "All namespaces must have a `gatekeeper` label"
+            labels:
+            - key: "gatekeeper"

--- a/test/resources/case17_gatekeeper_sync/case17constrainttemplate.yaml
+++ b/test/resources/case17_gatekeeper_sync/case17constrainttemplate.yaml
@@ -1,7 +1,7 @@
 apiVersion: templates.gatekeeper.sh/v1
 kind: ConstraintTemplate
 metadata:
-  name: case17k8srequiredlabels
+  name: case17constrainttemplate
   annotations:
     metadata.gatekeeper.sh/title: "Required Labels"
     metadata.gatekeeper.sh/version: 1.0.0
@@ -12,7 +12,7 @@ spec:
   crd:
     spec:
       names:
-        kind: Case17K8sRequiredLabels
+        kind: Case17ConstraintTemplate
       validation:
         legacySchema: false
         openAPIV3Schema:

--- a/test/resources/case17_gatekeeper_sync/case17constrainttemplateextra.yaml
+++ b/test/resources/case17_gatekeeper_sync/case17constrainttemplateextra.yaml
@@ -1,0 +1,60 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: case17constrainttemplateextra
+  annotations:
+    metadata.gatekeeper.sh/title: "Required Annotations"
+    metadata.gatekeeper.sh/version: 1.0.0
+    description: >-
+      Requires resources to contain specified annotations, with values matching
+      provided regular expressions.
+spec:
+  crd:
+    spec:
+      names:
+        kind: Case17ConstraintTemplateExtra
+      validation:
+        legacySchema: false
+        openAPIV3Schema:
+          type: object
+          properties:
+            message:
+              type: string
+            annotations:
+              type: array
+              description: >-
+                A list of annotations and values the object must specify.
+              items:
+                type: object
+                properties:
+                  key:
+                    type: string
+                    description: >-
+                      The required annotation.
+                  allowedRegex:
+                    type: string
+                    description: >-
+                      If specified, a regular expression the annotation's value
+                      must match. The value must contain at least one match for
+                      the regular expression.
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package k8srequiredannotations
+
+        violation[{"msg": msg, "details": {"missing_annotations": missing}}] {
+            provided := {annotation | input.review.object.metadata.annotations[annotation]}
+            required := {annotation | annotation := input.parameters.annotations[_].key}
+            missing := required - provided
+            count(missing) > 0
+            msg := sprintf("you must provide annotation(s): %v", [missing])
+        }
+
+        violation[{"msg": msg}] {
+          value := input.review.object.metadata.annotations[key]
+          expected := input.parameters.annotations[_]
+          expected.key == key
+          expected.allowedRegex != ""
+          not re_match(expected.allowedRegex, value)
+          msg := sprintf("Annotation <%v: %v> does not satisfy allowed regex: %v", [key, value, expected.allowedRegex])
+        }

--- a/test/resources/case17_gatekeeper_sync/case17k8srequiredlabels.yaml
+++ b/test/resources/case17_gatekeeper_sync/case17k8srequiredlabels.yaml
@@ -1,0 +1,72 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: case17k8srequiredlabels
+  annotations:
+    metadata.gatekeeper.sh/title: "Required Labels"
+    metadata.gatekeeper.sh/version: 1.0.0
+    description: >-
+      Requires resources to contain specified labels, with values matching
+      provided regular expressions.
+spec:
+  crd:
+    spec:
+      names:
+        kind: Case17K8sRequiredLabels
+      validation:
+        legacySchema: false
+        openAPIV3Schema:
+          type: object
+          properties:
+            message:
+              type: string
+            labels:
+              type: array
+              description: >-
+                A list of labels and values the object must specify.
+              items:
+                type: object
+                properties:
+                  key:
+                    type: string
+                    description: >-
+                      The required label.
+                  allowedRegex:
+                    type: string
+                    description: >-
+                      If specified, a regular expression the annotation's value
+                      must match. The value must contain at least one match for
+                      the regular expression.
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package k8srequiredlabels
+
+        get_message(parameters, _default) = msg {
+          not parameters.message
+          msg := _default
+        }
+
+        get_message(parameters, _default) = msg {
+          msg := parameters.message
+        }
+
+        violation[{"msg": msg, "details": {"missing_labels": missing}}] {
+          provided := {label | input.review.object.metadata.labels[label]}
+          required := {label | label := input.parameters.labels[_].key}
+          missing := required - provided
+          count(missing) > 0
+          def_msg := sprintf("you must provide labels: %v", [missing])
+          msg := get_message(input.parameters, def_msg)
+        }
+
+        violation[{"msg": msg}] {
+          value := input.review.object.metadata.labels[key]
+          expected := input.parameters.labels[_]
+          expected.key == key
+          # do not match if allowedRegex is not defined, or is an empty string
+          expected.allowedRegex != ""
+          not re_match(expected.allowedRegex, value)
+          def_msg := sprintf("Label <%v: %v> does not satisfy allowed regex: %v", [key, value, expected.allowedRegex])
+          msg := get_message(input.parameters, def_msg)
+        }

--- a/test/utils/common.go
+++ b/test/utils/common.go
@@ -14,6 +14,12 @@ import (
 	"k8s.io/client-go/tools/record"
 )
 
+var (
+	GkVersion    = "v3.11.0"
+	GkDeployment = "https://raw.githubusercontent.com/open-policy-agent/gatekeeper/" +
+		GkVersion + "/deploy/gatekeeper.yaml"
+)
+
 // CreateRecorder return recorder
 func CreateRecorder(kubeClient kubernetes.Interface, componentName string) (record.EventRecorder, error) {
 	eventsScheme := runtime.NewScheme()


### PR DESCRIPTION
ConstraintTemplates are a concept of the Open Policy Agent, handled by
the Gatekeeper framework. They are clusterwide so require some special
handling to sync, including manual cleanup since controller garbage
collection only cleans up owned objects in the same namespace. They
also do not have a status, so their creation/update generates an event
for the status sync to pick up.

ref: https://issues.redhat.com/browse/ACM-3327