### PR TITLE
Add the Gatekeeper constraint status sync controller

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -283,6 +283,10 @@ install-resources:
 	-kubectl create ns $(MANAGED_CLUSTER_NAME) --kubeconfig=$(HUB_CONFIG)
 	@echo creating namespace on managed
 	-kubectl create ns $(MANAGED_CLUSTER_NAME) --kubeconfig=$(MANAGED_CONFIG)
+	@if [ "$(KIND_VERSION)" != "minimum" ]; then \
+		echo installing Gatekeeper on the managed cluster; \
+		kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper/v3.11.0/deploy/gatekeeper.yaml  --kubeconfig=$(MANAGED_CONFIG); \
+	fi
 
 .PHONY: e2e-dependencies
 e2e-dependencies:

--- a/controllers/gatekeepersync/gatekeeper_constraint_sync.go
+++ b/controllers/gatekeepersync/gatekeeper_constraint_sync.go
@@ -1,0 +1,426 @@
+// Copyright Contributors to the Open Cluster Management project
+
+package gatekeepersync
+
+import (
+	"context"
+	"crypto/sha1"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+
+	depclient "github.com/stolostron/kubernetes-dependency-watches/client"
+	admissionregistration "k8s.io/api/admissionregistration/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+	policyv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	"open-cluster-management.io/governance-policy-framework-addon/controllers/utils"
+)
+
+const (
+	ControllerName        = "gatekeeper-constraint-status-sync"
+	GatekeeperWebhookName = "gatekeeper-validating-webhook-configuration"
+)
+
+var log = logf.Log.WithName(ControllerName)
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *GatekeeperConstraintReconciler) SetupWithManager(mgr ctrl.Manager, constraintEvents *source.Channel) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&policyv1.Policy{}).
+		WithEventFilter(policyPredicates()).
+		WithOptions(controller.Options{MaxConcurrentReconciles: 5}).
+		Watches(constraintEvents, &handler.EnqueueRequestForObject{}).
+		Named(ControllerName).
+		Complete(r)
+}
+
+// blank assignment to verify that ReconcilePolicy implements reconcile.Reconciler
+var _ reconcile.Reconciler = &GatekeeperConstraintReconciler{}
+
+// Used to track sent messages for a particular Gatekeeper constraint.
+type policyKindName struct {
+	Policy string
+	Kind   string
+	Name   string
+}
+
+// GatekeeperConstraintReconciler is responsible for relaying Gatekeeper constraint audit results as policy status
+// events.
+type GatekeeperConstraintReconciler struct {
+	client.Client
+	utils.ComplianceEventSender
+	Scheme             *runtime.Scheme
+	DynamicClient      dynamic.Interface
+	ConstraintsWatcher depclient.DynamicWatcher
+	// A cache of sent messages to avoid repeating status events due to race conditions. Each value is a SHA1
+	// digest.
+	lastSentMessages sync.Map
+}
+
+//+kubebuilder:rbac:groups=policy.open-cluster-management.io,resources=policies,verbs=get;list;watch
+//+kubebuilder:rbac:groups=constraints.gatekeeper.sh,resources=*,verbs=create;get;list;watch
+//+kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfigurations,resourceNames=gatekeeper-validating-webhook-configuration,verbs=get;list;watch
+//+kubebuilder:rbac:groups=core,resources=events,verbs=create;delete;get;list;patch;update;watch
+
+// Reconcile handles Policy objects that contain a Gatekeeper constraint and relays status messages from Gatekeeper
+// audit results. Every time a Gatekeeper constraint in a Policy is updated, a reconcile on the Policy is triggered.
+func (r *GatekeeperConstraintReconciler) Reconcile(
+	ctx context.Context, request reconcile.Request,
+) (
+	reconcile.Result, error,
+) {
+	log := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+	log.Info("Reconciling a Policy with one or more Gatekeeper constraints")
+
+	policyObjID := depclient.ObjectIdentifier{
+		Group:     policyv1.GroupVersion.Group,
+		Version:   policyv1.GroupVersion.Version,
+		Kind:      "Policy",
+		Namespace: request.Namespace,
+		Name:      request.Name,
+	}
+	policy := &policyv1.Policy{}
+
+	err := r.Get(ctx, request.NamespacedName, policy)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			log.V(1).Info("The Policy was deleted. Cleaning up watchers and status message cache.")
+
+			r.lastSentMessages.Range(func(key, value any) bool {
+				keyTyped := key.(policyKindName)
+				if keyTyped.Policy == request.Name {
+					r.lastSentMessages.Delete(keyTyped)
+				}
+
+				return true
+			})
+
+			err := r.ConstraintsWatcher.RemoveWatcher(policyObjID)
+			if errors.Is(err, depclient.ErrInvalidInput) {
+				log.Error(err, "Could not construct a valid object identifier for the policy. Will not retry.")
+
+				return reconcile.Result{}, nil
+			}
+
+			return reconcile.Result{}, err
+		}
+
+		log.Error(err, "Failed to get the Policy from the cache. Will retry the reconcile request.")
+
+		return reconcile.Result{}, err
+	}
+
+	constraintsToWatch := []depclient.ObjectIdentifier{}
+	constraintsSet := map[policyKindName]bool{}
+
+	for templateIndex, template := range policy.Spec.PolicyTemplates {
+		templateMap := map[string]interface{}{}
+
+		err := json.Unmarshal(template.ObjectDefinition.Raw, &templateMap)
+		if err != nil {
+			log.Error(
+				err,
+				"The policy template is invalid. Skipping this policy template.",
+				"policyTemplateIndex", fmt.Sprintf("%d", templateIndex),
+			)
+
+			continue
+		}
+
+		templateUnstructured := unstructured.Unstructured{Object: templateMap}
+		templateGVK := templateUnstructured.GroupVersionKind()
+
+		if templateGVK.Group != utils.GConstraint {
+			continue
+		}
+
+		constraintObjID := depclient.ObjectIdentifier{
+			Group:     templateGVK.Group,
+			Version:   templateGVK.Version,
+			Kind:      templateGVK.Kind,
+			Namespace: templateUnstructured.GetNamespace(),
+			Name:      templateUnstructured.GetName(),
+		}
+		constraintsToWatch = append(constraintsToWatch, constraintObjID)
+
+		pkn := policyKindName{Policy: policy.Name, Kind: templateGVK.Kind, Name: templateUnstructured.GetName()}
+		constraintsSet[pkn] = true
+
+		contraintGVR := schema.GroupVersionResource{
+			Group: utils.GConstraint,
+			// https://github.com/open-policy-agent/frameworks/blob/v0.9.0/constraint/pkg/client/crds/crds.go#L34
+			Resource: strings.ToLower(templateGVK.Kind),
+			// This uses v1beta1 even if the constraint in the template may have a newer version in the future so that
+			// the schema is consistent for status parsing. At the time of this writing, v1beta1 is the latest.
+			Version: "v1beta1",
+		}
+
+		constraint, err := r.DynamicClient.Resource(contraintGVR).Get(
+			ctx, templateUnstructured.GetName(), metav1.GetOptions{},
+		)
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				log.Info(
+					"The Gatekeeper constraint does not exist on the cluster yet. "+
+						"Will retry the reconcile request once it's created.",
+					"constraint", constraintObjID.String(),
+				)
+
+				continue
+			}
+
+			log.Error(
+				err, "Failed to get the constraint. Will retry the reconcile request.", "constraint", constraintObjID,
+			)
+
+			return reconcile.Result{}, err
+		}
+
+		violations, _, err := unstructured.NestedSlice(constraint.Object, "status", "violations")
+		if err != nil {
+			log.Error(err, "The constraint status is invalid", "constraint", constraintObjID)
+
+			err := r.sendComplianceEvent(
+				ctx, policy, constraint, templateIndex, "The constraint status is invalid", policyv1.NonCompliant,
+			)
+			if err != nil {
+				log.Error(err, "Failed to send the compliance event")
+
+				return reconcile.Result{}, err
+			}
+
+			continue
+		}
+
+		if len(violations) == 0 {
+			err := r.sendComplianceEvent(
+				ctx, policy, constraint, templateIndex, "The constraint has no violations", policyv1.Compliant,
+			)
+			if err != nil {
+				log.Error(err, "Failed to send the compliance event")
+
+				return reconcile.Result{}, err
+			}
+
+			continue
+		}
+
+		msg := ""
+
+		for _, violation := range violations {
+			violation, ok := violation.(map[string]interface{})
+			if !ok {
+				log.Info(
+					"The Gatekeeper constraint's status.violations field is in an invalid format. Skipping for now.",
+				)
+
+				continue
+			}
+
+			if msg != "" {
+				msg += "; "
+			}
+
+			var name string
+			if ns, ok := violation["namespace"]; ok {
+				name = ns.(string) + "/" + violation["name"].(string)
+			} else {
+				name = violation["name"].(string)
+			}
+
+			msg += fmt.Sprintf(
+				"%s - %s (on %s %s)",
+				violation["enforcementAction"],
+				violation["message"],
+				violation["kind"],
+				name,
+			)
+		}
+
+		err = r.sendComplianceEvent(ctx, policy, constraint, templateIndex, msg, policyv1.NonCompliant)
+		if err != nil {
+			log.Error(err, "Failed to send the compliance event")
+
+			return reconcile.Result{}, err
+		}
+	}
+
+	// Clear the status message cache for any removed constraints in the policy since the last reconcile
+	r.lastSentMessages.Range(func(key, value any) bool {
+		keyTyped := key.(policyKindName)
+		if keyTyped.Policy == policy.Name && !constraintsSet[keyTyped] {
+			r.lastSentMessages.Delete(keyTyped)
+		}
+
+		return true
+	})
+
+	// This is true if a policy used to have Gatekeeper constraints but now does not.
+	if len(constraintsToWatch) == 0 {
+		err = r.ConstraintsWatcher.RemoveWatcher(policyObjID)
+		if err != nil {
+			log.Error(err, "Failed to remove the watches on the constraints")
+
+			return reconcile.Result{}, err
+		}
+	} else {
+		err = r.ConstraintsWatcher.AddOrUpdateWatcher(policyObjID, constraintsToWatch...)
+		if err != nil {
+			log.Error(err, "Failed to update the watches on the constraints")
+
+			return reconcile.Result{}, err
+		}
+	}
+
+	return reconcile.Result{}, nil
+}
+
+// sendComplianceEvent wraps SendComplianceEvent and only sends an event if it isn't already set in the policy.
+// Additionally, it adjust the compliance and message if the validating webhook is disabled and the constraint's
+// enforcementAction is set to deny.
+func (r *GatekeeperConstraintReconciler) sendComplianceEvent(
+	ctx context.Context,
+	policy *policyv1.Policy,
+	constraint *unstructured.Unstructured,
+	templateIndex int,
+	msg string,
+	compliance policyv1.ComplianceState,
+) error {
+	enforcementAction, err := getEnforcementAction(constraint)
+	if err != nil {
+		log.Error(err, "The enforcementAction is invalid. Assuming it's not deny.")
+	}
+
+	if enforcementAction == "deny" {
+		webhookEnabled, err := r.webhookEnabled(ctx)
+		if err != nil {
+			log.Error(err, "Failed to determine if the Gatekeeper webhook is enabled")
+
+			return err
+		}
+
+		if !webhookEnabled {
+			compliance = policyv1.NonCompliant
+			msg = fmt.Sprintf(
+				"The Gatekeeper validating webhook is disabled but the constraint's spec.enforcementAction is %s. %s",
+				enforcementAction,
+				msg,
+			)
+		}
+	}
+
+	refreshedPolicy := &policyv1.Policy{}
+
+	err = r.Get(ctx, types.NamespacedName{Namespace: policy.Namespace, Name: policy.Name}, refreshedPolicy)
+	if err != nil {
+		log.Error(err, "Failed to refresh the cached policy. Will use potentially stale policy for history comparison.")
+
+		refreshedPolicy = policy
+	}
+
+	owner := metav1.OwnerReference{
+		APIVersion: refreshedPolicy.APIVersion,
+		Kind:       refreshedPolicy.Kind,
+		Name:       refreshedPolicy.Name,
+		UID:        refreshedPolicy.UID,
+	}
+	kn := policyKindName{Policy: policy.Name, Kind: constraint.GetKind(), Name: constraint.GetName()}
+
+	if len(refreshedPolicy.Status.Details) < templateIndex+1 ||
+		len(refreshedPolicy.Status.Details[templateIndex].History) == 0 ||
+		refreshedPolicy.Status.Details[templateIndex].History[0].Message != fmt.Sprintf("%s; %s", compliance, msg) {
+		msgSHA1 := sha1.Sum([]byte(msg))
+		if existingMsgSHA1, ok := r.lastSentMessages.Load(kn); ok && existingMsgSHA1.([20]byte) == msgSHA1 {
+			// The message was already sent.
+			return nil
+		}
+
+		err := r.SendEvent(ctx, constraint, owner, msg, compliance)
+		if err != nil {
+			return err
+		}
+
+		r.lastSentMessages.Store(kn, msgSHA1)
+	} else {
+		// The message is already recorded in the Policy status so the sent message in the cache can be removed. This
+		// way if the status message on the Policy is overwritten/deleted, a new status event is sent.
+		r.lastSentMessages.Delete(kn)
+	}
+
+	return nil
+}
+
+// webhookEnabled verifies that the Gatekeeper validating webhook is enabled.
+func (r *GatekeeperConstraintReconciler) webhookEnabled(ctx context.Context) (bool, error) {
+	webhookConfig := admissionregistration.ValidatingWebhookConfiguration{}
+
+	err := r.Get(ctx, types.NamespacedName{Name: GatekeeperWebhookName}, &webhookConfig)
+	if err == nil {
+		for _, webhook := range webhookConfig.Webhooks {
+			if webhook.Name == "validation.gatekeeper.sh" {
+				return true, nil
+			}
+		}
+	} else if k8serrors.IsNotFound(err) {
+		return false, nil
+	}
+
+	return false, err
+}
+
+// Copied from github.com/open-policy-agent/frameworks/constraint/pkg/apis/constraints
+// getEnforcementAction returns a Constraint's enforcementAction, which indicates
+// what should be done if a review violates a Constraint, or the Constraint fails
+// to run.
+//
+// Returns an error if spec.enforcementAction is defined and is not a string.
+func getEnforcementAction(constraint *unstructured.Unstructured) (string, error) {
+	action, found, err := unstructured.NestedString(constraint.Object, "spec", "enforcementAction")
+	if err != nil {
+		return "", fmt.Errorf("invalid spec.enforcementAction: %w", err)
+	}
+
+	if !found {
+		return "deny", nil
+	}
+
+	return action, nil
+}
+
+// hasGatekeeperConstraints checks a policy's policy-templates array to determine if it contains a Gatekeeper
+// Constraint.
+func hasGatekeeperConstraints(policy *policyv1.Policy) bool {
+	for _, template := range policy.Spec.PolicyTemplates {
+		templateMap := map[string]interface{}{}
+
+		err := json.Unmarshal(template.ObjectDefinition.Raw, &templateMap)
+		if err != nil {
+			continue
+		}
+
+		templateUnstructured := unstructured.Unstructured{Object: templateMap}
+		templateGVK := templateUnstructured.GroupVersionKind()
+
+		if templateGVK.Group == utils.GConstraint {
+			return true
+		}
+	}
+
+	return false
+}

--- a/controllers/gatekeepersync/health.go
+++ b/controllers/gatekeepersync/health.go
@@ -1,0 +1,97 @@
+// Copyright Contributors to the Open Cluster Management project
+
+package gatekeepersync
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	apiWatch "k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/watch"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+
+	"open-cluster-management.io/governance-policy-framework-addon/controllers/utils"
+)
+
+// GatekeeperInstallationChecker is a health checker for a health endpoint that fails if Gatekeeper's installation
+// status changes or the passed in health checker functions fail. This is useful for Kubernetes to trigger a restart
+// to either enable or disable the gatekeeper-constraint-status-sync controller based on the Gatekeeper installation
+// status.
+func GatekeeperInstallationChecker(
+	ctx context.Context, dynamicClient dynamic.Interface, checkers ...healthz.Checker,
+) (
+	healthz.Checker, bool, error,
+) {
+	fieldSelector := fmt.Sprintf("metadata.name=constrainttemplates.%s", utils.GvkConstraintTemplate.Group)
+	timeout := int64(30)
+	crdGVR := schema.GroupVersionResource{
+		Group:    "apiextensions.k8s.io",
+		Version:  "v1",
+		Resource: "customresourcedefinitions",
+	}
+
+	listResult, err := dynamicClient.Resource(crdGVR).List(
+		ctx, metav1.ListOptions{FieldSelector: fieldSelector, TimeoutSeconds: &timeout},
+	)
+	if err != nil {
+		return nil, false, err
+	}
+
+	gatekeeperInstalled := len(listResult.Items) > 0
+	resourceVersion := listResult.GetResourceVersion()
+
+	watchFunc := func(options metav1.ListOptions) (apiWatch.Interface, error) {
+		options.FieldSelector = fieldSelector
+
+		return dynamicClient.Resource(crdGVR).Watch(ctx, options)
+	}
+
+	w, err := watch.NewRetryWatcher(resourceVersion, &cache.ListWatch{WatchFunc: watchFunc})
+	if err != nil {
+		return nil, false, err
+	}
+
+	var lastHealthErr error
+
+	return func(req *http.Request) error {
+		if lastHealthErr != nil {
+			return lastHealthErr
+		}
+
+		select {
+		case <-w.Done():
+			select {
+			case <-ctx.Done():
+				// Stop the retry watcher if the parent context is canceled.
+				w.Stop()
+
+				lastHealthErr = errors.New("the context is closed so the health check can no longer be performed")
+			default:
+				lastHealthErr = errors.New("the watch used by the Gatekeeper installation checker ended prematurely")
+			}
+		case result := <-w.ResultChan():
+			if !gatekeeperInstalled && result.Type == apiWatch.Added {
+				lastHealthErr = errors.New("the controller needs to restart because Gatekeeper has been installed")
+			}
+
+			if gatekeeperInstalled && result.Type == apiWatch.Deleted {
+				lastHealthErr = errors.New("the controller needs to restart because Gatekeeper has been uninstalled")
+			}
+		default:
+			for _, checker := range checkers {
+				err := checker(req)
+				if err != nil {
+					return err
+				}
+			}
+		}
+
+		return lastHealthErr
+	}, gatekeeperInstalled, nil
+}

--- a/controllers/gatekeepersync/policy_predicate.go
+++ b/controllers/gatekeepersync/policy_predicate.go
@@ -1,0 +1,35 @@
+// Copyright Contributors to the Open Cluster Management project
+
+package gatekeepersync
+
+import (
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// policyPredicates filters out policies without Gatekeeper constraints and policy updates without the generation
+// changing.
+func policyPredicates() predicate.Funcs {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			policy := e.Object.(*policiesv1.Policy)
+
+			return hasGatekeeperConstraints(policy)
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldPolicy := e.ObjectOld.(*policiesv1.Policy)
+			updatedPolicy := e.ObjectNew.(*policiesv1.Policy)
+
+			if oldPolicy.Generation == updatedPolicy.Generation {
+				return false
+			}
+
+			// oldPolicy is also checked in the event all the Gatekeeper constraints were removed.
+			return hasGatekeeperConstraints(oldPolicy) || hasGatekeeperConstraints(updatedPolicy)
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return true
+		},
+	}
+}

--- a/controllers/utils/events.go
+++ b/controllers/utils/events.go
@@ -1,0 +1,95 @@
+// Copyright Contributors to the Open Cluster Management project
+
+package utils
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	policyv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ComplianceEventSender handles sending policy template status events in the correct format.
+type ComplianceEventSender struct {
+	ClusterNamespace string
+	InstanceName     string
+	ClientSet        *kubernetes.Clientset
+	ControllerName   string
+}
+
+// SendEvent will send a policy template status message update synchronously as opposed to EventRecorder
+// sending events in the background asynchronously.
+func (c *ComplianceEventSender) SendEvent(
+	ctx context.Context,
+	instance client.Object,
+	owner metav1.OwnerReference,
+	msg string,
+	compliance policyv1.ComplianceState,
+) error {
+	msg = string(compliance) + "; " + msg
+	if len([]rune(msg)) > 1024 {
+		msg = string([]rune(msg)[:1021]) + "..."
+	}
+
+	now := time.Now()
+	var reason string
+
+	if instance.GetNamespace() == "" {
+		reason = "policy: " + instance.GetName()
+	} else {
+		reason = fmt.Sprintf("policy: %s/%s", instance.GetNamespace(), instance.GetName())
+	}
+
+	gvk := instance.GetObjectKind().GroupVersionKind()
+
+	event := &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			// This event name matches the convention of recorders from client-go
+			Name:      fmt.Sprintf("%v.%x", owner.Name, now.UnixNano()),
+			Namespace: c.ClusterNamespace,
+		},
+		InvolvedObject: corev1.ObjectReference{
+			Kind:       owner.Kind,
+			Namespace:  c.ClusterNamespace, // k8s ensures owners are always in the same namespace
+			Name:       owner.Name,
+			UID:        owner.UID,
+			APIVersion: owner.APIVersion,
+		},
+
+		Reason:  reason,
+		Message: msg,
+		Source: corev1.EventSource{
+			Component: c.ControllerName,
+			Host:      c.InstanceName,
+		},
+		FirstTimestamp: metav1.NewTime(now),
+		LastTimestamp:  metav1.NewTime(now),
+		Count:          1,
+		Type:           "Normal",
+		EventTime:      metav1.NewMicroTime(now),
+		Action:         "ComplianceStateUpdate",
+		Related: &corev1.ObjectReference{
+			Kind:       gvk.Kind,
+			Name:       instance.GetName(),
+			Namespace:  instance.GetNamespace(),
+			UID:        instance.GetUID(),
+			APIVersion: gvk.GroupVersion().String(),
+		},
+		ReportingController: c.ControllerName,
+		ReportingInstance:   c.InstanceName,
+	}
+
+	if compliance == policyv1.NonCompliant {
+		event.Type = "Warning"
+	}
+
+	eventClient := c.ClientSet.CoreV1().Events(c.ClusterNamespace)
+	_, err := eventClient.Create(ctx, event, metav1.CreateOptions{})
+
+	return err
+}

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -49,6 +49,16 @@ metadata:
   name: governance-policy-framework-addon
 rules:
 - apiGroups:
+  - admissionregistration.k8s.io
+  resourceNames:
+  - gatekeeper-validating-webhook-configuration
+  resources:
+  - validatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions

--- a/deploy/rbac/role.yaml
+++ b/deploy/rbac/role.yaml
@@ -7,6 +7,16 @@ metadata:
   name: governance-policy-framework-addon
 rules:
 - apiGroups:
+  - admissionregistration.k8s.io
+  resourceNames:
+  - gatekeeper-validating-webhook-configuration
+  resources:
+  - validatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions

--- a/test/e2e/case17_gatekeeper_sync_test.go
+++ b/test/e2e/case17_gatekeeper_sync_test.go
@@ -5,68 +5,151 @@ package e2e
 
 import (
 	"context"
+	"fmt"
+	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/errors"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	policyv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 	propagatorutils "open-cluster-management.io/governance-policy-propagator/test/utils"
 
-	"open-cluster-management.io/governance-policy-framework-addon/test/utils"
+	"open-cluster-management.io/governance-policy-framework-addon/controllers/gatekeepersync"
 )
 
-var _ = Describe("Test Gatekeeper ConstraintTemplate sync", Ordered, Label("skip-minimum"), func() {
+var _ = Describe("Test Gatekeeper ConstraintTemplate and constraint sync", Ordered, Label("skip-minimum"), func() {
 	const (
-		caseNumber                string = "case17"
-		yamlBasePath              string = "../resources/" + caseNumber + "_gatekeeper_sync/"
-		policyName                string = caseNumber + "-gk-policy"
-		policyYaml                string = yamlBasePath + policyName + ".yaml"
-		policyYamlExtra           string = yamlBasePath + policyName + "-extra.yaml"
-		policyName2               string = policyName + "-2"
-		policyYaml2               string = yamlBasePath + policyName2 + ".yaml"
-		gkConstraintTemplateName  string = caseNumber + "constrainttemplate"
-		gkConstraintTemplateYaml  string = yamlBasePath + gkConstraintTemplateName + ".yaml"
-		gkConstraintTmplNameExtra string = gkConstraintTemplateName + "extra"
-		gkConstraintTmplYamlExtra string = yamlBasePath + gkConstraintTmplNameExtra + ".yaml"
-		gkConstraintName          string = caseNumber + "-gk-constraint"
-		gkConstraintYaml          string = yamlBasePath + gkConstraintName + ".yaml"
-		gkConstraintName2         string = gkConstraintName + "-2"
-		gkConstraintYaml2         string = yamlBasePath + gkConstraintName2 + ".yaml"
-		gkConstraintNameExtra     string = gkConstraintName + "-extra"
-		gkConstraintYamlExtra     string = yamlBasePath + gkConstraintNameExtra + ".yaml"
+		caseNumber                string        = "case17"
+		configMapName             string        = caseNumber + "-test"
+		configMap2Name            string        = caseNumber + "-test2"
+		configMap3Name            string        = caseNumber + "-test3"
+		configMapNamespace        string        = caseNumber + "-gk-test"
+		yamlBasePath              string        = "../resources/" + caseNumber + "_gatekeeper_sync/"
+		policyName                string        = caseNumber + "-gk-policy"
+		policyYaml                string        = yamlBasePath + policyName + ".yaml"
+		policyYamlExtra           string        = yamlBasePath + policyName + "-extra.yaml"
+		policyName2               string        = policyName + "-2"
+		policyYaml2               string        = yamlBasePath + policyName2 + ".yaml"
+		gkAuditFrequency          time.Duration = time.Minute
+		gkConstraintTemplateName  string        = caseNumber + "constrainttemplate"
+		gkConstraintTemplateYaml  string        = yamlBasePath + gkConstraintTemplateName + ".yaml"
+		gkConstraintTmplNameExtra string        = gkConstraintTemplateName + "extra"
+		gkConstraintTmplYamlExtra string        = yamlBasePath + gkConstraintTmplNameExtra + ".yaml"
+		gkConstraintName          string        = caseNumber + "-gk-constraint"
+		gkConstraintYaml          string        = yamlBasePath + gkConstraintName + ".yaml"
+		gkConstraintName2         string        = gkConstraintName + "-2"
+		gkConstraintYaml2         string        = yamlBasePath + gkConstraintName2 + ".yaml"
+		gkConstraintNameExtra     string        = gkConstraintName + "-extra"
+		gkConstraintYamlExtra     string        = yamlBasePath + gkConstraintNameExtra + ".yaml"
 	)
 	gvrConstraint := schema.GroupVersionResource{
 		Group:    gvConstraintGroup,
 		Version:  "v1beta1",
 		Resource: caseNumber + "constrainttemplate",
 	}
+
 	BeforeAll(func() {
-		DeployGatekeeper()
+		By("Creating the namespace " + configMapNamespace)
+		ns := &corev1.Namespace{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Namespace",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: configMapNamespace,
+			},
+		}
+
+		_, err := clientManaged.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
+		Expect(err).To(BeNil())
+
+		Eventually(func(g Gomega) {
+			deployments, err := clientManaged.AppsV1().Deployments("gatekeeper-system").
+				List(context.TODO(), metav1.ListOptions{})
+			g.Expect(err).Should(BeNil())
+			g.Expect(deployments.Items).ToNot(HaveLen(0))
+
+			var available bool
+			for _, deployment := range deployments.Items {
+				for _, condition := range deployment.Status.Conditions {
+					if condition.Reason == "MinimumReplicasAvailable" {
+						available = condition.Status == "True"
+					}
+				}
+				g.Expect(available).To(BeTrue())
+			}
+		}, defaultTimeoutSeconds, 1).Should(Succeed())
 	})
+
 	AfterAll(func() {
 		for _, pName := range []string{policyName, policyName2} {
 			By("Deleting policy " + pName + " on the hub in ns:" + clusterNamespaceOnHub)
 			err := clientHubDynamic.Resource(gvrPolicy).Namespace(clusterNamespaceOnHub).Delete(
 				context.TODO(), pName, metav1.DeleteOptions{},
 			)
-			if !errors.IsNotFound(err) {
+			if !k8serrors.IsNotFound(err) {
 				Expect(err).To(BeNil())
 			}
-			By("Cleaning up the events from policy " + pName)
-			_, err = kubectlManaged("delete", "events", "-n", clusterNamespace, "--ignore-not-found",
+
+			By("Cleaning up the events for the policy " + pName)
+			_, err = kubectlManaged(
+				"delete",
+				"events",
+				"-n",
+				clusterNamespace,
 				"--field-selector=involvedObject.name="+pName,
+				"--ignore-not-found",
 			)
 			Expect(err).To(BeNil())
 		}
+
 		opt := metav1.ListOptions{}
 		propagatorutils.ListWithTimeout(clientManagedDynamic, gvrPolicy, opt, 0, true, defaultTimeoutSeconds)
 
-		By("Deleting Gatekeeper " + utils.GkVersion + " from the managed cluster")
-		_, err := kubectlManaged("delete", "-f", utils.GkDeployment)
-		Expect(err).Should(BeNil())
+		By("Deleting the namespace " + configMapNamespace)
+		err := clientManaged.CoreV1().Namespaces().Delete(context.TODO(), configMapNamespace, metav1.DeleteOptions{})
+		if !k8serrors.IsNotFound(err) {
+			Expect(err).To(BeNil())
+		}
+
+		By("Fixing the Gatekeeper webhook if required")
+		Eventually(
+			func(g Gomega) {
+				webhook, err := clientManaged.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(
+					context.TODO(), gatekeepersync.GatekeeperWebhookName, metav1.GetOptions{},
+				)
+				g.Expect(err).To(BeNil())
+
+				fixed := false
+
+				for i := range webhook.Webhooks {
+					if strings.HasPrefix(webhook.Webhooks[i].Name, "not-") {
+						webhook.Webhooks[i].Name = strings.TrimPrefix(webhook.Webhooks[i].Name, "not-")
+						fixed = true
+					}
+				}
+
+				if !fixed {
+					return
+				}
+
+				By("Updating the Gatekeeper webhook")
+				_, err = clientManaged.AdmissionregistrationV1().ValidatingWebhookConfigurations().Update(
+					context.TODO(), webhook, metav1.UpdateOptions{},
+				)
+				g.Expect(err).To(BeNil())
+			},
+			defaultTimeoutSeconds,
+			1,
+		).Should(Succeed())
 	})
+
 	It("should create the policy on the managed cluster", func() {
 		By("Creating policy " + policyName + " on the hub in ns:" + clusterNamespaceOnHub)
 		_, err := kubectlHub("apply", "-f", policyYaml, "-n", clusterNamespaceOnHub)
@@ -81,6 +164,7 @@ var _ = Describe("Test Gatekeeper ConstraintTemplate sync", Ordered, Label("skip
 			defaultTimeoutSeconds)
 		Expect(plc).NotTo(BeNil())
 	})
+
 	It("should create Gatekeeper constraints on the managed cluster", func() {
 		By("Checking for the synced ConstraintTemplate " + gkConstraintTemplateName)
 		expectedConstraintTemplate := propagatorutils.ParseYaml(gkConstraintTemplateYaml)
@@ -107,6 +191,7 @@ var _ = Describe("Test Gatekeeper ConstraintTemplate sync", Ordered, Label("skip
 			return trustedPlc.Object["spec"]
 		}, defaultTimeoutSeconds, 1).Should(propagatorutils.SemanticEqual(expectedConstraint2.Object["spec"]))
 	})
+
 	It("should set status for the ConstraintTemplate to Compliant", func() {
 		By("Checking if policy status is compliant for the ConstraintTemplate")
 		managedPlc := propagatorutils.GetWithTimeout(clientManagedDynamic, gvrPolicy, policyName, clusterNamespace,
@@ -125,6 +210,205 @@ var _ = Describe("Test Gatekeeper ConstraintTemplate sync", Ordered, Label("skip
 			return compliance
 		}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
 	})
+
+	It("should return Gatekeeper audit results", func() {
+		By("Checking if policy status is compliant for the constraint")
+		Eventually(func(g Gomega) {
+			managedPolicyUnstructured := propagatorutils.GetWithTimeout(
+				clientManagedDynamic, gvrPolicy, policyName, clusterNamespace, true, defaultTimeoutSeconds,
+			)
+
+			managedPolicy := policyv1.Policy{}
+			err := runtime.DefaultUnstructuredConverter.FromUnstructured(
+				managedPolicyUnstructured.Object, &managedPolicy,
+			)
+			g.Expect(err).To(BeNil())
+
+			g.Expect(managedPolicy.Status.Details).To(HaveLen(2))
+			g.Expect(managedPolicy.Status.Details[1].TemplateMeta.GetName()).To(Equal(gkConstraintName))
+			history := managedPolicy.Status.Details[1].History
+			g.Expect(len(history)).ToNot(Equal(0))
+			expectedMsg := "Compliant; The constraint has no violations"
+			g.Expect(history[0].Message).To(
+				Equal(expectedMsg),
+				fmt.Sprintf("Got %s but expected %s", history[0].Message, expectedMsg),
+			)
+		}, gkAuditFrequency*3, 1).Should(Succeed())
+
+		By("Adding ConfigMaps that violate the constraint")
+		for _, cmName := range []string{configMapName, configMap2Name} {
+			configMap := &corev1.ConfigMap{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "ConfigMap",
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      cmName,
+					Namespace: configMapNamespace,
+				},
+			}
+
+			_, err := clientManaged.CoreV1().ConfigMaps(configMapNamespace).Create(
+				context.TODO(), configMap, metav1.CreateOptions{},
+			)
+			Expect(err).To(BeNil())
+		}
+
+		By("Checking if policy status is noncompliant for the constraint")
+		Eventually(func(g Gomega) {
+			managedPolicyUnstructured := propagatorutils.GetWithTimeout(
+				clientManagedDynamic, gvrPolicy, policyName, clusterNamespace, true, defaultTimeoutSeconds,
+			)
+
+			managedPolicy := policyv1.Policy{}
+			err := runtime.DefaultUnstructuredConverter.FromUnstructured(
+				managedPolicyUnstructured.Object, &managedPolicy,
+			)
+			g.Expect(err).To(BeNil())
+
+			history := managedPolicy.Status.Details[1].History
+			g.Expect(len(history)).ToNot(Equal(0))
+			expectedMsg := `NonCompliant; warn - All configmaps must have a 'my-gk-test' label (on ConfigMap ` +
+				`case17-gk-test/case17-test); warn - All configmaps must have a 'my-gk-test' label (on ConfigMap ` +
+				`case17-gk-test/case17-test2)`
+			g.Expect(history[0].Message).To(
+				Equal(expectedMsg),
+				fmt.Sprintf("Got %s but expected %s", history[0].Message, expectedMsg),
+			)
+
+			// Verify that there are no duplicate status messages.
+			for i, historyEvent := range managedPolicy.Status.Details[1].History {
+				if i == 0 || strings.HasPrefix(historyEvent.Message, "NonCompliant; template-error;") {
+					continue
+				}
+
+				g.Expect(managedPolicy.Status.Details[1].History[i-1].Message).ToNot(Equal(historyEvent.Message))
+			}
+		}, gkAuditFrequency*3, 1).Should(Succeed())
+	})
+
+	It("should deny an invalid ConfigMap when remediationAction=enforce", func() {
+		By("Patching the remediationAction to enforce")
+		Eventually(
+			func() interface{} {
+				managedPlc := propagatorutils.GetWithTimeout(
+					clientHubDynamic, gvrPolicy, policyName, clusterNamespaceOnHub, true, defaultTimeoutSeconds,
+				)
+				_, err := patchRemediationAction(clientHubDynamic, managedPlc, "enforce")
+
+				return err
+			},
+			defaultTimeoutSeconds,
+			1,
+		).Should(BeNil())
+
+		By("Waiting for the Constraint to have enforcementAction=deny")
+		Eventually(
+			func(g Gomega) {
+				constraint, err := clientManagedDynamic.Resource(gvrConstraint).Get(
+					context.TODO(), gkConstraintName, metav1.GetOptions{},
+				)
+				g.Expect(err).To(BeNil())
+
+				action, _, _ := unstructured.NestedString(constraint.Object, "spec", "enforcementAction")
+				g.Expect(action).To(Equal("deny"))
+			},
+			defaultTimeoutSeconds,
+			1,
+		).Should(Succeed())
+
+		By("Trying to create a ConfigMap that violates the constraint")
+		configMap := &corev1.ConfigMap{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "ConfigMap",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      configMap3Name,
+				Namespace: configMapNamespace,
+			},
+		}
+
+		_, err := clientManaged.CoreV1().ConfigMaps(configMapNamespace).Create(
+			context.TODO(), configMap, metav1.CreateOptions{},
+		)
+		Expect(err).ToNot(BeNil())
+		Expect(err.Error()).To(
+			Equal(
+				`admission webhook "validation.gatekeeper.sh" denied the request: [` + gkConstraintName + `] All ` +
+					`configmaps must have a 'my-gk-test' label`,
+			),
+		)
+	})
+
+	It("should have an error if the remediationAction=enforce and the Gatekeeper webhook is not enabled", func() {
+		By("Renaming the Gatekeeper webhook")
+		Eventually(
+			func(g Gomega) {
+				webhook, err := clientManaged.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(
+					context.TODO(), gatekeepersync.GatekeeperWebhookName, metav1.GetOptions{},
+				)
+				g.Expect(err).To(BeNil())
+
+				for i := range webhook.Webhooks {
+					webhook.Webhooks[i].Name = "not-" + webhook.Webhooks[i].Name
+				}
+
+				_, err = clientManaged.AdmissionregistrationV1().ValidatingWebhookConfigurations().Update(
+					context.TODO(), webhook, metav1.UpdateOptions{},
+				)
+				g.Expect(err).To(BeNil())
+			},
+			defaultTimeoutSeconds,
+			1,
+		).Should(Succeed())
+
+		By("Checking if policy status is noncompliant for the constraint")
+		Eventually(func(g Gomega) {
+			managedPolicyUnstructured := propagatorutils.GetWithTimeout(
+				clientManagedDynamic, gvrPolicy, policyName, clusterNamespace, true, defaultTimeoutSeconds,
+			)
+
+			managedPolicy := policyv1.Policy{}
+			err := runtime.DefaultUnstructuredConverter.FromUnstructured(
+				managedPolicyUnstructured.Object, &managedPolicy,
+			)
+			g.Expect(err).To(BeNil())
+
+			history := managedPolicy.Status.Details[1].History
+			g.Expect(len(history)).ToNot(Equal(0))
+			expectedMsg := `NonCompliant; The Gatekeeper validating webhook is disabled but the constraint's ` +
+				`spec.enforcementAction is deny. deny - All configmaps must have a 'my-gk-test' label (on ConfigMap ` +
+				`case17-gk-test/case17-test); deny - All configmaps must have a 'my-gk-test' label (on ConfigMap ` +
+				`case17-gk-test/case17-test2)`
+			g.Expect(history[0].Message).To(
+				Equal(expectedMsg),
+				fmt.Sprintf("Got %s but expected %s", history[0].Message, expectedMsg),
+			)
+		}, gkAuditFrequency*3, 1).Should(Succeed())
+
+		By("Restoring the Gatekeeper webhook")
+		Eventually(
+			func(g Gomega) {
+				webhook, err := clientManaged.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(
+					context.TODO(), gatekeepersync.GatekeeperWebhookName, metav1.GetOptions{},
+				)
+				g.Expect(err).To(BeNil())
+
+				for i := range webhook.Webhooks {
+					webhook.Webhooks[i].Name = strings.TrimPrefix(webhook.Webhooks[i].Name, "not-")
+				}
+
+				_, err = clientManaged.AdmissionregistrationV1().ValidatingWebhookConfigurations().Update(
+					context.TODO(), webhook, metav1.UpdateOptions{},
+				)
+				g.Expect(err).To(BeNil())
+			},
+			defaultTimeoutSeconds,
+			1,
+		).Should(Succeed())
+	})
+
 	It("should add a Constraint and ConstraintTemplate when added to policy-templates", func() {
 		By("Adding a Constraint and ConstraintTemplate to the policy-templates array")
 		_, err := kubectlHub("apply", "-f", policyYamlExtra, "-n", clusterNamespaceOnHub)
@@ -146,6 +430,7 @@ var _ = Describe("Test Gatekeeper ConstraintTemplate sync", Ordered, Label("skip
 			return trustedPlc.Object["spec"]
 		}, defaultTimeoutSeconds, 1).Should(propagatorutils.SemanticEqual(expectedConstraintTmpl.Object["spec"]))
 	})
+
 	It("should remove a Constraint and ConstraintTemplate when removed from policy-templates", func() {
 		By("Removing a Constraint and ConstraintTemplate from the policy-templates array")
 		_, err := kubectlHub("apply", "-f", policyYaml, "-n", clusterNamespaceOnHub)
@@ -161,6 +446,7 @@ var _ = Describe("Test Gatekeeper ConstraintTemplate sync", Ordered, Label("skip
 				gkConstraintTmplNameExtra, "", false, defaultTimeoutSeconds)
 		}, defaultTimeoutSeconds, 1).Should(BeNil())
 	})
+
 	It("should delete template policy on managed cluster", func() {
 		By("Deleting parent policies")
 		_, err := kubectlHub("delete", "-f", policyYaml, "-n", clusterNamespaceOnHub)

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -241,6 +241,7 @@ func kubectlManaged(args ...string) (string, error) {
 	return propagatorutils.KubectlWithOutput(args...)
 }
 
+// nolint: unparam
 func patchRemediationAction(
 	client dynamic.Interface, plc *unstructured.Unstructured, remediationAction string,
 ) (
@@ -290,26 +291,4 @@ func hubApplyPolicy(name, path string) {
 		true,
 		defaultTimeoutSeconds)
 	ExpectWithOffset(1, hubPlc).NotTo(BeNil())
-}
-
-func DeployGatekeeper() {
-	By("Deploying Gatekeeper " + utils.GkVersion + " to the managed cluster")
-	_, err := kubectlManaged("apply", "-f", utils.GkDeployment)
-	Expect(err).Should(BeNil())
-
-	EventuallyWithOffset(1, func(g Gomega) {
-		deployments, err := clientManaged.AppsV1().Deployments("gatekeeper-system").
-			List(context.TODO(), metav1.ListOptions{})
-		g.Expect(err).Should(BeNil())
-
-		var available bool
-		for _, deployment := range deployments.Items {
-			for _, condition := range deployment.Status.Conditions {
-				if condition.Reason == "MinimumReplicasAvailable" {
-					available = condition.Status == "True"
-				}
-			}
-			g.Expect(available).To(BeTrue())
-		}
-	}, defaultTimeoutSeconds, 1).Should(Succeed())
 }

--- a/test/resources/case17_gatekeeper_sync/case17-gk-constraint.yaml
+++ b/test/resources/case17_gatekeeper_sync/case17-gk-constraint.yaml
@@ -7,8 +7,11 @@ spec:
   match:
     kinds:
       - apiGroups: [""]
-        kinds: ["Namespace"]
+        kinds: ["ConfigMap"]
+    scope: Namespaced
+    namespaces:
+      - case17-gk-test
   parameters:
-    message: "All namespaces must have a `gatekeeper` label"
+    message: "All configmaps must have a 'my-gk-test' label"
     labels:
-    - key: "gatekeeper"
+    - key: "my-gk-test"

--- a/test/resources/case17_gatekeeper_sync/case17-gk-policy-extra.yaml
+++ b/test/resources/case17_gatekeeper_sync/case17-gk-policy-extra.yaml
@@ -59,6 +59,8 @@ spec:
                 }
 
                 violation[{"msg": msg, "details": {"missing_labels": missing}}] {
+                  input.review.object.metadata.name != "kube-root-ca.crt"
+                  input.review.object.metadata.name != "openshift-service-ca.crt"
                   provided := {label | input.review.object.metadata.labels[label]}
                   required := {label | label := input.parameters.labels[_].key}
                   missing := required - provided
@@ -68,6 +70,8 @@ spec:
                 }
 
                 violation[{"msg": msg}] {
+                  input.review.object.metadata.name != "kube-root-ca.crt"
+                  input.review.object.metadata.name != "openshift-service-ca.crt"
                   value := input.review.object.metadata.labels[key]
                   expected := input.parameters.labels[_]
                   expected.key == key
@@ -145,11 +149,14 @@ spec:
           match:
             kinds:
               - apiGroups: [""]
-                kinds: ["Namespace"]
+                kinds: ["ConfigMap"]
+            scope: Namespaced
+            namespaces:
+              - case17-gk-test
           parameters:
-            message: "All namespaces must have a `gatekeeper` label"
+            message: "All configmaps must have a 'my-gk-test' label"
             labels:
-              - key: "gatekeeper"
+            - key: "my-gk-test"
     - objectDefinition:
         apiVersion: constraints.gatekeeper.sh/v1beta1
         kind: Case17ConstraintTemplate

--- a/test/resources/case17_gatekeeper_sync/case17-gk-policy.yaml
+++ b/test/resources/case17_gatekeeper_sync/case17-gk-policy.yaml
@@ -61,6 +61,8 @@ spec:
                 }
 
                 violation[{"msg": msg, "details": {"missing_labels": missing}}] {
+                  input.review.object.metadata.name != "kube-root-ca.crt"
+                  input.review.object.metadata.name != "openshift-service-ca.crt"
                   provided := {label | input.review.object.metadata.labels[label]}
                   required := {label | label := input.parameters.labels[_].key}
                   missing := required - provided
@@ -70,6 +72,8 @@ spec:
                 }
 
                 violation[{"msg": msg}] {
+                  input.review.object.metadata.name != "kube-root-ca.crt"
+                  input.review.object.metadata.name != "openshift-service-ca.crt"
                   value := input.review.object.metadata.labels[key]
                   expected := input.parameters.labels[_]
                   expected.key == key
@@ -89,8 +93,11 @@ spec:
           match:
             kinds:
               - apiGroups: [""]
-                kinds: ["Namespace"]
+                kinds: ["ConfigMap"]
+            scope: Namespaced
+            namespaces:
+              - case17-gk-test
           parameters:
-            message: "All namespaces must have a `gatekeeper` label"
+            message: "All configmaps must have a 'my-gk-test' label"
             labels:
-            - key: "gatekeeper"
+            - key: "my-gk-test"

--- a/test/resources/case17_gatekeeper_sync/case17constrainttemplate.yaml
+++ b/test/resources/case17_gatekeeper_sync/case17constrainttemplate.yaml
@@ -52,6 +52,8 @@ spec:
         }
 
         violation[{"msg": msg, "details": {"missing_labels": missing}}] {
+          input.review.object.metadata.name != "kube-root-ca.crt"
+          input.review.object.metadata.name != "openshift-service-ca.crt"
           provided := {label | input.review.object.metadata.labels[label]}
           required := {label | label := input.parameters.labels[_].key}
           missing := required - provided
@@ -61,6 +63,8 @@ spec:
         }
 
         violation[{"msg": msg}] {
+          input.review.object.metadata.name != "kube-root-ca.crt"
+          input.review.object.metadata.name != "openshift-service-ca.crt"
           value := input.review.object.metadata.labels[key]
           expected := input.parameters.labels[_]
           expected.key == key

--- a/test/utils/common.go
+++ b/test/utils/common.go
@@ -14,12 +14,6 @@ import (
 	"k8s.io/client-go/tools/record"
 )
 
-var (
-	GkVersion    = "v3.11.0"
-	GkDeployment = "https://raw.githubusercontent.com/open-policy-agent/gatekeeper/" +
-		GkVersion + "/deploy/gatekeeper.yaml"
-)
-
 // CreateRecorder return recorder
 func CreateRecorder(kubeClient kubernetes.Interface, componentName string) (record.EventRecorder, error) {
 	eventsScheme := runtime.NewScheme()


### PR DESCRIPTION
This controller is responsible for relaying Gatekeeper constraint audit results as policy status events for constraints associated with a policy.

The controller will only start if Gatekeeper is installed. If Gatekeeper's installation status changes while the controller manager is running, the health endpoint will return as unhealthy to cause Kubernetes to restart the pod to then enable/disable this new controller.

Relates:
https://issues.redhat.com/browse/ACM-3328