### PR TITLE
Perform discovery API calls only as needed

### DIFF
--- a/controllers/utils/utils.go
+++ b/controllers/utils/utils.go
@@ -2,12 +2,15 @@ package utils
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/api/equality"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
 	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 	"open-cluster-management.io/governance-policy-propagator/controllers/common"
 )
@@ -24,6 +27,7 @@ var (
 		{Group: GvkConstraintTemplate.Group, Kind: GvkConstraintTemplate.Kind},
 		{Group: GConstraint},
 	}
+	ErrNoVersionedResource = errors.New("the resource version was not found")
 )
 
 const (
@@ -117,4 +121,37 @@ func (e ErrList) Aggregate() error {
 	}
 
 	return err
+}
+
+// GVRFromGVK uses the discovery client to get the versioned resource and determines if the resource is namespaced. If
+// the resource is not found or could not be retrieved, an error is always returned.
+func GVRFromGVK(
+	discoveryClient discovery.DiscoveryInterface, gvk schema.GroupVersionKind,
+) (
+	schema.GroupVersionResource, bool, error,
+) {
+	rsrcList, err := discoveryClient.ServerResourcesForGroupVersion(gvk.GroupVersion().String())
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return schema.GroupVersionResource{}, false, fmt.Errorf("%w: %s", ErrNoVersionedResource, gvk.String())
+		}
+
+		return schema.GroupVersionResource{}, false, err
+	}
+
+	for _, rsrc := range rsrcList.APIResources {
+		if rsrc.Kind == gvk.Kind {
+			gvr := schema.GroupVersionResource{
+				Group:    gvk.Group,
+				Version:  gvk.Version,
+				Resource: rsrc.Name,
+			}
+
+			return gvr, rsrc.Namespaced, nil
+		}
+	}
+
+	return schema.GroupVersionResource{}, false, fmt.Errorf(
+		"%w: no matching kind was found: %s", ErrNoVersionedResource, gvk.String(),
+	)
 }

--- a/test/e2e/case17_gatekeeper_sync_test.go
+++ b/test/e2e/case17_gatekeeper_sync_test.go
@@ -194,11 +194,11 @@ var _ = Describe("Test Gatekeeper ConstraintTemplate and constraint sync", Order
 
 	It("should set status for the ConstraintTemplate to Compliant", func() {
 		By("Checking if policy status is compliant for the ConstraintTemplate")
-		managedPlc := propagatorutils.GetWithTimeout(clientManagedDynamic, gvrPolicy, policyName, clusterNamespace,
-			true, defaultTimeoutSeconds)
-		Expect(managedPlc).NotTo(BeNil())
-
 		Eventually(func() string {
+			managedPlc := propagatorutils.GetWithTimeout(clientManagedDynamic, gvrPolicy, policyName, clusterNamespace,
+				true, defaultTimeoutSeconds)
+			Expect(managedPlc).NotTo(BeNil())
+
 			var compliance string
 			detailsSlice, found, err := unstructured.NestedSlice(managedPlc.Object, "status", "details")
 			if found {


### PR DESCRIPTION
This commit changes the discovery REST mapper that was used to be targeted to
that specific resource version.

This is to reduce load on the Kubernetes API as well as to reduce the chance
of long delays due to queries per second (QPS) exceeding the default limit.

An additional commit was added to prevent watches being created on Gatekeeper constraints without the corresponding CRD installed.

Other commits are to address flaky tests.

Relates:
https://issues.redhat.com/browse/ACM-4518