### PR TITLE
3329 finalizer cleanup

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -79,16 +79,21 @@ jobs:
         export COVERAGE_E2E_OUT=coverage_e2e_hosted_mode.out
         make e2e-test-coverage
 
+    - name: Verify Deployment Configuration
+      run: |
+        make build-images
+        make kind-deploy-controller-dev
+
+    - name: Run E2E Uninstallation Tests
+      if: ${{ matrix.kind == 'latest' }}
+      run: |
+        make e2e-test-uninstall-coverage
+
     - name: Test Coverage Verification
       if: ${{ github.event_name == 'pull_request' && matrix.kind == 'latest' }}
       run: |
         make test-coverage
         make coverage-verify
-
-    - name: Verify Deployment Configuration
-      run: |
-        make build-images
-        make kind-deploy-controller-dev
 
     - name: Debug
       if: ${{ failure() }}

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,8 @@ endif
 export COVERAGE_MIN ?= 69
 COVERAGE_E2E_OUT ?= coverage_e2e.out
 
+export OSDK_FORCE_RUN_MODE ?= local
+
 # Image URL to use all building/pushing image targets;
 # Use your own docker registry and image name for dev/test by overridding the IMG and REGISTRY environment variable.
 IMG ?= $(shell cat COMPONENT_NAME 2> /dev/null)

--- a/Makefile
+++ b/Makefile
@@ -306,6 +306,20 @@ e2e-test-coverage: e2e-run-instrumented e2e-test e2e-stop-instrumented
 e2e-test-coverage-foreground: LOG_REDIRECT = 
 e2e-test-coverage-foreground: e2e-test-coverage
 
+.PHONY: e2e-test-uninistall
+e2e-test-uninistall:
+	$(GINKGO) -v --fail-fast --json-report=report_e2e_uninstall.json --output-dir=. --label-filter='uninstall' \
+	 --covermode=atomic --coverprofile=coverage_e2e_uninstall_trigger.out \
+	 --coverpkg=open-cluster-management.io/governance-policy-framework-addon/controllers/uninstall test/e2e
+
+.PHONY: e2e-test-uninstall-coverage
+e2e-test-uninstall-coverage: COVERAGE_E2E_OUT = coverage_e2e_uninstall_controller.out
+e2e-test-uninstall-coverage: e2e-run-instrumented scale-down-deployment e2e-test-uninistall e2e-stop-instrumented
+
+.PHONY: scale-down-deployment
+scale-down-deployment:
+	kubectl scale deployment $(IMG) -n $(KIND_NAMESPACE) --replicas=0 --kubeconfig=$(MANAGED_CONFIG)
+
 .PHONY: e2e-build-instrumented
 e2e-build-instrumented:
 	go test -covermode=atomic -coverpkg=$(shell cat go.mod | head -1 | cut -d ' ' -f 2)/... -c -tags e2e ./ -o build/_output/bin/$(IMG)-instrumented

--- a/controllers/gatekeepersync/gatekeeper_constraint_sync.go
+++ b/controllers/gatekeepersync/gatekeeper_constraint_sync.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	"open-cluster-management.io/governance-policy-framework-addon/controllers/uninstall"
 	"open-cluster-management.io/governance-policy-framework-addon/controllers/utils"
 )
 
@@ -89,6 +90,13 @@ func (r *GatekeeperConstraintReconciler) Reconcile(
 	reconcile.Result, error,
 ) {
 	log := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+
+	if uninstall.DeploymentIsUninstalling {
+		log.Info("Skipping reconcile because the deployment is in uninstallation mode")
+
+		return reconcile.Result{}, nil
+	}
+
 	log.Info("Reconciling a Policy with one or more Gatekeeper constraints")
 
 	policyObjID := depclient.ObjectIdentifier{

--- a/controllers/secretsync/secret_sync.go
+++ b/controllers/secretsync/secret_sync.go
@@ -16,6 +16,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"open-cluster-management.io/governance-policy-framework-addon/controllers/uninstall"
 )
 
 const (
@@ -55,6 +57,13 @@ func (r *SecretReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 	reqLogger := log.WithValues(
 		"Request.Namespace", request.Namespace, "Request.Name", request.Name, "TargetNamespace", r.TargetNamespace,
 	)
+
+	if uninstall.DeploymentIsUninstalling {
+		log.Info("Skipping reconcile because the deployment is in uninstallation mode")
+
+		return reconcile.Result{}, nil
+	}
+
 	reqLogger.Info("Reconciling Secret")
 	// The cache configuration of SelectorsByObject should prevent this from happening, but add this as a precaution.
 	if request.Name != SecretName {

--- a/controllers/specsync/policy_spec_sync.go
+++ b/controllers/specsync/policy_spec_sync.go
@@ -19,6 +19,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"open-cluster-management.io/governance-policy-framework-addon/controllers/uninstall"
 	"open-cluster-management.io/governance-policy-framework-addon/controllers/utils"
 )
 
@@ -65,6 +66,13 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 	reqLogger := log.WithValues(
 		"Request.Namespace", request.Namespace, "Request.Name", request.Name, "TargetNamespace", r.TargetNamespace,
 	)
+
+	if uninstall.DeploymentIsUninstalling {
+		log.Info("Skipping reconcile because the deployment is in uninstallation mode")
+
+		return reconcile.Result{}, nil
+	}
+
 	reqLogger.Info("Reconciling Policy...")
 
 	// Fetch the Policy instance

--- a/controllers/statussync/policy_status_sync.go
+++ b/controllers/statussync/policy_status_sync.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	"open-cluster-management.io/governance-policy-framework-addon/controllers/uninstall"
 	"open-cluster-management.io/governance-policy-framework-addon/controllers/utils"
 )
 
@@ -80,6 +81,13 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 	reqLogger := log.WithValues(
 		"Request.Namespace", request.Namespace, "Request.Name", request.Name, "HubNamespace", r.ClusterNamespaceOnHub,
 	)
+
+	if uninstall.DeploymentIsUninstalling {
+		log.Info("Skipping reconcile because the deployment is in uninstallation mode")
+
+		return reconcile.Result{}, nil
+	}
+
 	reqLogger.Info("Reconciling the policy")
 
 	// Fetch the Policy instance

--- a/controllers/uninstall/triggeruninstall.go
+++ b/controllers/uninstall/triggeruninstall.go
@@ -1,0 +1,203 @@
+package uninstall
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"time"
+
+	"github.com/spf13/pflag"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	policyv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var (
+	deploymentName      string
+	deploymentNamespace string
+	policyNamespace     string
+	timeoutSeconds      uint
+)
+
+var triggerLog = logf.Log.WithName("trigger-uninstall")
+
+const AnnotationKey = "policy.open-cluster-management.io/uninstalling"
+
+// Trigger adds the uninstallation annotation to the Deployment, then deletes all the policies.
+// It will return nil only when all the policies are gone.
+// It takes command line arguments to configure itself.
+func Trigger(args []string) error {
+	triggerLog.Info("Triggering uninstallation preparation")
+
+	if err := parseUninstallFlags(args); err != nil {
+		return err
+	}
+
+	terminatingCtx := ctrl.SetupSignalHandler()
+	ctx, cancelCtx := context.WithTimeout(terminatingCtx, time.Duration(timeoutSeconds)*time.Second)
+
+	defer cancelCtx()
+
+	// Get a config to talk to the apiserver
+	config, err := config.GetConfig()
+	if err != nil {
+		return err
+	}
+
+	client := kubernetes.NewForConfigOrDie(config)
+	dynamicClient := dynamic.NewForConfigOrDie(config)
+
+	err = setUninstallAnnotation(ctx, client)
+	if err != nil {
+		return err
+	}
+
+	// Give the running controllers some time to switch to uninstall mode,
+	// to try and reduce the number of conflicts and retries while deleting policies.
+	time.Sleep(5 * time.Second)
+
+	err = deletePolicies(ctx, dynamicClient)
+	if err != nil {
+		return err
+	}
+
+	triggerLog.Info("Uninstallation preparation complete")
+
+	return nil
+}
+
+func parseUninstallFlags(args []string) error {
+	triggerUninstallFlagSet := pflag.NewFlagSet("trigger-uninstall", pflag.ExitOnError)
+
+	triggerUninstallFlagSet.StringVar(
+		&deploymentName,
+		"deployment-name",
+		"governance-policy-framework-addon",
+		"The name of the controller Deployment object",
+	)
+	triggerUninstallFlagSet.StringVar(
+		&deploymentNamespace,
+		"deployment-namespace",
+		"open-cluster-management-agent-addon",
+		"The namespace of the controller Deployment object",
+	)
+	triggerUninstallFlagSet.StringVar(
+		&policyNamespace, "policy-namespace", "", "The namespace where the Policy objects are stored",
+	)
+	triggerUninstallFlagSet.UintVar(
+		&timeoutSeconds, "timeout-seconds", 300, "The number of seconds before the operation is canceled",
+	)
+	triggerUninstallFlagSet.AddGoFlagSet(flag.CommandLine)
+
+	err := triggerUninstallFlagSet.Parse(args)
+	if err != nil {
+		return err
+	}
+
+	if deploymentName == "" || deploymentNamespace == "" || policyNamespace == "" {
+		return errors.New("--deployment-name, --deployment-namespace, --policy-namespace must all have values")
+	}
+
+	if timeoutSeconds < 30 {
+		return errors.New("--timeout-seconds must be set to at least 30 seconds")
+	}
+
+	return nil
+}
+
+func setUninstallAnnotation(ctx context.Context, client *kubernetes.Clientset) error {
+	triggerLog.Info("Annotating the deployment with " + AnnotationKey + " = true")
+
+	for {
+		var err error
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("context canceled before the uninstallation preparation was complete")
+		default:
+		}
+
+		deploymentRsrc := client.AppsV1().Deployments(deploymentNamespace)
+
+		deployment, err := deploymentRsrc.Get(ctx, deploymentName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		annotations := deployment.GetAnnotations()
+		annotations[AnnotationKey] = "true"
+		deployment.SetAnnotations(annotations)
+
+		_, err = deploymentRsrc.Update(ctx, deployment, metav1.UpdateOptions{})
+		if err != nil {
+			if k8serrors.IsServerTimeout(err) || k8serrors.IsTimeout(err) || k8serrors.IsConflict(err) {
+				triggerLog.Error(err, "Retrying setting the Deployment uninstall annotation due to error")
+
+				continue
+			}
+
+			return err
+		}
+
+		break
+	}
+
+	return nil
+}
+
+func deletePolicies(ctx context.Context, dynamicClient dynamic.Interface) error {
+	policyGVR := schema.GroupVersionResource{
+		Group:    policyv1.GroupVersion.Group,
+		Version:  policyv1.GroupVersion.Version,
+		Resource: "policies",
+	}
+
+	triggerLog.Info("Deleting all policies from the cluster")
+
+	policyInterface := dynamicClient.Resource(policyGVR).Namespace(policyNamespace)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("context canceled before the uninstallation preparation was complete")
+		default:
+		}
+
+		policies, err := policyInterface.List(ctx, metav1.ListOptions{})
+		if err != nil {
+			if k8serrors.IsServerTimeout(err) || k8serrors.IsTimeout(err) {
+				triggerLog.Error(err, "Unable to list policy objects, retrying.")
+
+				continue
+			}
+
+			return err
+		}
+
+		switch len(policies.Items) {
+		case 0:
+			triggerLog.Info("No policies found.")
+
+			return nil
+		case 1:
+			triggerLog.Info("Found 1 policy.")
+		default:
+			triggerLog.Info(fmt.Sprintf("Found %v policies.", len(policies.Items)))
+		}
+
+		err = policyInterface.DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{})
+		if err != nil {
+			log.Error(err, "Unable to delete all policies. Will retry.")
+		}
+
+		triggerLog.Info("The uninstall preparation is not complete. Sleeping two seconds before checking again.")
+		time.Sleep(2 * time.Second)
+	}
+}

--- a/controllers/uninstall/watcher.go
+++ b/controllers/uninstall/watcher.go
@@ -1,0 +1,127 @@
+package uninstall
+
+import (
+	"context"
+
+	"github.com/stolostron/kubernetes-dependency-watches/client"
+	"k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	ControllerName = "uninstall-watcher"
+	DeploymentName = "governance-policy-framework-addon"
+)
+
+var (
+	log                      = logf.Log.WithName(ControllerName)
+	DeploymentIsUninstalling = false
+)
+
+type reconciler struct {
+	*kubernetes.Clientset
+}
+
+// +kubebuilder:rbac:groups=apps,resources=deployments,resourceNames=governance-policy-framework-addon,verbs=get;list;watch;patch;update
+
+func (r *reconciler) Reconcile(ctx context.Context, obj client.ObjectIdentifier) (reconcile.Result, error) {
+	log := log.WithValues("name", obj.Name, "namespace", obj.Namespace)
+
+	if DeploymentIsUninstalling {
+		log.Info("Skipping reconcile because the uninstall flag is already true. " +
+			"To reset the flag, stop this container.")
+
+		return reconcile.Result{}, nil
+	}
+
+	log.Info("Checking the deployment for the annotation " + AnnotationKey)
+
+	deployment, err := r.AppsV1().Deployments(obj.Namespace).Get(ctx, obj.Name, v1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			log.Error(err, "The deployment was not found. Assuming this means we are being uninstalled.")
+
+			DeploymentIsUninstalling = true
+
+			return reconcile.Result{}, nil
+		}
+
+		log.Error(err, "Error getting deployment, requeueing")
+
+		return reconcile.Result{}, err
+	}
+
+	if deployment.GetAnnotations()[AnnotationKey] == "true" {
+		log.Info("Annotation " + AnnotationKey + " found and was true. Setting the uninstall flag.")
+
+		DeploymentIsUninstalling = true
+
+		return reconcile.Result{}, nil
+	}
+
+	log.Info("Annotation " + AnnotationKey + " not found, or not true. No changes.")
+
+	return reconcile.Result{}, nil
+}
+
+// StartWatcher starts the uninstall watcher, which watches the controller's Deployment so that when
+// the uninstallation annotation is present, the global uninstallation flag will be set to true.
+func StartWatcher(ctx context.Context, mgr manager.Manager, namespace string) error {
+	config := mgr.GetConfig()
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return err
+	}
+
+	// Create the dynamic watcher.
+	dynamicWatcher, err := client.New(config, &reconciler{clientset}, nil)
+	if err != nil {
+		return err
+	}
+
+	watcherErr := make(chan error)
+
+	// Start the dynamic watcher in a separate goroutine
+	go func() {
+		err := dynamicWatcher.Start(ctx)
+		if err != nil {
+			watcherErr <- err
+		}
+	}()
+
+	// Wait until the dynamic watcher has started.
+	select {
+	case <-dynamicWatcher.Started():
+		break
+	case watchErr := <-watcherErr:
+		return watchErr
+	}
+
+	self := client.ObjectIdentifier{
+		Group:     "apps",
+		Version:   "v1",
+		Kind:      "Deployment",
+		Namespace: namespace,
+		Name:      DeploymentName,
+	}
+
+	err = dynamicWatcher.AddOrUpdateWatcher(self, self)
+	if err != nil {
+		return err
+	}
+
+	// Run until the context is canceled.
+	select {
+	case <-ctx.Done():
+		break
+	case watchErr := <-watcherErr:
+		return watchErr
+	}
+
+	return nil
+}

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -66,6 +66,18 @@ rules:
   - list
   - watch
 - apiGroups:
+  - apps
+  resourceNames:
+  - governance-policy-framework-addon
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - constraints.gatekeeper.sh
   resources:
   - '*'

--- a/deploy/rbac/role.yaml
+++ b/deploy/rbac/role.yaml
@@ -24,6 +24,18 @@ rules:
   - list
   - watch
 - apiGroups:
+  - apps
+  resourceNames:
+  - governance-policy-framework-addon
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - constraints.gatekeeper.sh
   resources:
   - '*'

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stolostron/go-log-utils/zaputil"
 	depclient "github.com/stolostron/kubernetes-dependency-watches/client"
 	admissionregistration "k8s.io/api/admissionregistration/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	extensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	extensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
@@ -54,6 +55,7 @@ import (
 	"open-cluster-management.io/governance-policy-framework-addon/controllers/specsync"
 	"open-cluster-management.io/governance-policy-framework-addon/controllers/statussync"
 	"open-cluster-management.io/governance-policy-framework-addon/controllers/templatesync"
+	"open-cluster-management.io/governance-policy-framework-addon/controllers/uninstall"
 	"open-cluster-management.io/governance-policy-framework-addon/controllers/utils"
 	"open-cluster-management.io/governance-policy-framework-addon/tool"
 	"open-cluster-management.io/governance-policy-framework-addon/version"
@@ -85,6 +87,7 @@ func init() {
 	utilruntime.Must(extensionsv1beta1.AddToScheme(scheme))
 	utilruntime.Must(gktemplatesv1.AddToScheme(scheme))
 	utilruntime.Must(gktemplatesv1beta1.AddToScheme(scheme))
+	utilruntime.Must(appsv1.AddToScheme(scheme))
 }
 
 func main() {
@@ -298,6 +301,35 @@ func main() {
 
 		wg.Done()
 	}()
+
+	operatorNs, err := tool.GetOperatorNamespace()
+
+	if errors.Is(err, tool.ErrRunLocal) {
+		log.Info("Using default operatorNs for the uninstall-watcher during this local run")
+
+		operatorNs = "open-cluster-management-agent-addon"
+		err = nil
+	}
+
+	if err != nil {
+		log.Error(err, "Failed to get operator namespace")
+		os.Exit(1)
+	} else {
+		wg.Add(1)
+
+		go func() {
+			if err := uninstall.StartWatcher(mgrCtx, mgr, operatorNs); err != nil {
+				log.Error(err, "problem running uninstall-watcher")
+
+				// On errors, the parent context (mainCtx) may not have closed, so cancel the child context.
+				mgrCtxCancel()
+
+				errorExit = true
+			}
+
+			wg.Done()
+		}()
+	}
 
 	if !tool.Options.DisableSpecSync {
 		wg.Add(1)

--- a/main.go
+++ b/main.go
@@ -91,6 +91,16 @@ func init() {
 }
 
 func main() {
+	// specially handle the uninstall command, otherwise try to start the controllers.
+	if len(os.Args) >= 2 && os.Args[1] == "trigger-uninstall" {
+		if err := uninstall.Trigger(os.Args[2:]); err != nil {
+			log.Error(err, "Failed to trigger uninstallation preparation")
+			os.Exit(1)
+		}
+
+		return
+	}
+
 	zflags := zaputil.FlagConfig{
 		LevelName:   "log-level",
 		EncoderName: "log-encoder",

--- a/test/e2e/case18_uninstall_test.go
+++ b/test/e2e/case18_uninstall_test.go
@@ -1,0 +1,125 @@
+// Copyright (c) 2023 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package e2e
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	propagatorutils "open-cluster-management.io/governance-policy-propagator/test/utils"
+
+	"open-cluster-management.io/governance-policy-framework-addon/controllers/uninstall"
+)
+
+var _ = Describe("Test uninstallation procedure", Ordered, Label("uninstall"), func() {
+	suiteConfig, _ := GinkgoConfiguration()
+
+	if suiteConfig.LabelFilter != "uninstall" {
+		// If the label filter isn't *exactly* "uninstall", then don't run these uninstall tests.
+		// It's not _the_best_ way to do this, but it is _a_ way to do this.
+		return
+	}
+
+	const (
+		caseNumber         string = "case18"
+		configMapName      string = caseNumber + "-test"
+		configMapNamespace string = caseNumber + "-gk-test"
+		yamlBasePath       string = "../resources/" + caseNumber + "_uninstall/"
+		policyName         string = caseNumber + "-gk-policy"
+		policyYaml         string = yamlBasePath + policyName + ".yaml"
+		policyYamlUpdated  string = yamlBasePath + policyName + "-updated.yaml"
+		gkConstraintName   string = caseNumber + "-gk-constraint"
+		constraintResource string = caseNumber + "constrainttemplate"
+	)
+	gvrConstraint := schema.GroupVersionResource{
+		Group:    gvConstraintGroup,
+		Version:  "v1beta1",
+		Resource: constraintResource,
+	}
+
+	BeforeAll(func() {
+		By("Creating the namespace " + configMapNamespace)
+		ns := &corev1.Namespace{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Namespace",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: configMapNamespace,
+			},
+		}
+
+		_, err := clientManaged.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
+		Expect(err).To(BeNil())
+	})
+
+	AfterAll(func() {
+		By("Deleting policy " + policyName + " on the hub in ns:" + clusterNamespaceOnHub)
+		err := clientHubDynamic.Resource(gvrPolicy).Namespace(clusterNamespaceOnHub).Delete(
+			context.TODO(), policyName, metav1.DeleteOptions{},
+		)
+		if !k8serrors.IsNotFound(err) {
+			Expect(err).To(BeNil())
+		}
+
+		By("Cleaning up the events for the policy " + policyName)
+		_, err = kubectlManaged(
+			"delete",
+			"events",
+			"-n",
+			clusterNamespace,
+			"--field-selector=involvedObject.name="+policyName,
+			"--ignore-not-found",
+		)
+		Expect(err).To(BeNil())
+
+		opt := metav1.ListOptions{}
+		propagatorutils.ListWithTimeout(clientManagedDynamic, gvrPolicy, opt, 0, true, defaultTimeoutSeconds)
+
+		By("Deleting the namespace " + configMapNamespace)
+		err = clientManaged.CoreV1().Namespaces().Delete(context.TODO(), configMapNamespace, metav1.DeleteOptions{})
+		if !k8serrors.IsNotFound(err) {
+			Expect(err).To(BeNil())
+		}
+	})
+
+	It("should create the policy and create the constraint", func() {
+		By("Creating policy " + policyName + " on the hub in ns:" + clusterNamespaceOnHub)
+		_, err := kubectlHub("apply", "-f", policyYaml, "-n", clusterNamespaceOnHub)
+		Expect(err).Should(BeNil())
+		plc := propagatorutils.GetWithTimeout(clientManagedDynamic, gvrPolicy, policyName, clusterNamespace, true,
+			defaultTimeoutSeconds)
+		Expect(plc).NotTo(BeNil())
+
+		By("Checking for the synced Constraint " + gkConstraintName)
+		_ = propagatorutils.GetWithTimeout(clientManagedDynamic, gvrConstraint, gkConstraintName,
+			"", true, defaultTimeoutSeconds)
+	})
+
+	It("should make the uninstallation more interesting", func() {
+		By("Adding an invalid template to the policy")
+		_, err := kubectlHub("apply", "-f", policyYamlUpdated, "-n", clusterNamespaceOnHub)
+		Expect(err).Should(BeNil())
+
+		By("Adding a finalizer to the constraint")
+		_, err = kubectlManaged("patch", constraintResource, gkConstraintName, "--type=json",
+			`-p=[{"op":"add","path":"/metadata/finalizers","value":[test.io/foo]}]`)
+		Expect(err).Should(BeNil())
+	})
+
+	It("should trigger the uninstallation and successfully delete all the policies", func() {
+		// Note: the test runs in an env where the default KUBECONFIG is for the managed cluster
+		err := uninstall.Trigger([]string{"--policy-namespace=" + clusterNamespace, "--timeout-seconds=60"})
+		Expect(err).Should(BeNil())
+
+		By("Verifying there are no policies left on the managed cluster")
+		propagatorutils.ListWithTimeout(clientManagedDynamic, gvrPolicy, metav1.ListOptions{}, 0, true,
+			defaultTimeoutSeconds)
+	})
+})

--- a/test/resources/case18_uninstall/case18-gk-policy-updated.yaml
+++ b/test/resources/case18_uninstall/case18-gk-policy-updated.yaml
@@ -1,0 +1,106 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: case18-gk-policy
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: templates.gatekeeper.sh/v1
+        kind: ConstraintTemplate
+        metadata:
+          name: case18constrainttemplate
+          annotations:
+            metadata.gatekeeper.sh/title: "Required Labels"
+            metadata.gatekeeper.sh/version: 1.0.0
+            description: >-
+              Requires resources to contain specified labels, with values matching
+              provided regular expressions.
+        spec:
+          crd:
+            spec:
+              names:
+                kind: Case18ConstraintTemplate
+              validation:
+                legacySchema: false
+                openAPIV3Schema:
+                  type: object
+                  properties:
+                    message:
+                      type: string
+                    labels:
+                      type: array
+                      description: >-
+                        A list of labels and values the object must specify.
+                      items:
+                        type: object
+                        properties:
+                          key:
+                            type: string
+                            description: >-
+                              The required label.
+                          allowedRegex:
+                            type: string
+                            description: >-
+                              If specified, a regular expression the annotation's value
+                              must match. The value must contain at least one match for
+                              the regular expression.
+          targets:
+            - target: admission.k8s.gatekeeper.sh
+              rego: |
+                package k8srequiredlabels
+
+                get_message(parameters, _default) = msg {
+                  not parameters.message
+                  msg := _default
+                }
+
+                get_message(parameters, _default) = msg {
+                  msg := parameters.message
+                }
+
+                violation[{"msg": msg, "details": {"missing_labels": missing}}] {
+                  input.review.object.metadata.name != "kube-root-ca.crt"
+                  input.review.object.metadata.name != "openshift-service-ca.crt"
+                  provided := {label | input.review.object.metadata.labels[label]}
+                  required := {label | label := input.parameters.labels[_].key}
+                  missing := required - provided
+                  count(missing) > 0
+                  def_msg := sprintf("you must provide labels: %v", [missing])
+                  msg := get_message(input.parameters, def_msg)
+                }
+
+                violation[{"msg": msg}] {
+                  input.review.object.metadata.name != "kube-root-ca.crt"
+                  input.review.object.metadata.name != "openshift-service-ca.crt"
+                  value := input.review.object.metadata.labels[key]
+                  expected := input.parameters.labels[_]
+                  expected.key == key
+                  # do not match if allowedRegex is not defined, or is an empty string
+                  expected.allowedRegex != ""
+                  not re_match(expected.allowedRegex, value)
+                  def_msg := sprintf("Label <%v: %v> does not satisfy allowed regex: %v", [key, value, expected.allowedRegex])
+                  msg := get_message(input.parameters, def_msg)
+                }
+    - objectDefinition:
+        apiVersion: constraints.gatekeeper.sh/v1beta1
+        kind: Case18ConstraintTemplate
+        metadata:
+          name: case18-gk-constraint
+        spec:
+          enforcementAction: dryrun
+          match:
+            kinds:
+              - apiGroups: [""]
+                kinds: ["ConfigMap"]
+            scope: Namespaced
+            namespaces:
+              - case18-gk-test
+          parameters:
+            message: "All configmaps must have a 'my-gk-test' label"
+            labels:
+            - key: "my-gk-test"
+    - objectDefinition:
+        fee: fi
+        fo: fum

--- a/test/resources/case18_uninstall/case18-gk-policy.yaml
+++ b/test/resources/case18_uninstall/case18-gk-policy.yaml
@@ -1,0 +1,103 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: case18-gk-policy
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: templates.gatekeeper.sh/v1
+        kind: ConstraintTemplate
+        metadata:
+          name: case18constrainttemplate
+          annotations:
+            metadata.gatekeeper.sh/title: "Required Labels"
+            metadata.gatekeeper.sh/version: 1.0.0
+            description: >-
+              Requires resources to contain specified labels, with values matching
+              provided regular expressions.
+        spec:
+          crd:
+            spec:
+              names:
+                kind: Case18ConstraintTemplate
+              validation:
+                legacySchema: false
+                openAPIV3Schema:
+                  type: object
+                  properties:
+                    message:
+                      type: string
+                    labels:
+                      type: array
+                      description: >-
+                        A list of labels and values the object must specify.
+                      items:
+                        type: object
+                        properties:
+                          key:
+                            type: string
+                            description: >-
+                              The required label.
+                          allowedRegex:
+                            type: string
+                            description: >-
+                              If specified, a regular expression the annotation's value
+                              must match. The value must contain at least one match for
+                              the regular expression.
+          targets:
+            - target: admission.k8s.gatekeeper.sh
+              rego: |
+                package k8srequiredlabels
+
+                get_message(parameters, _default) = msg {
+                  not parameters.message
+                  msg := _default
+                }
+
+                get_message(parameters, _default) = msg {
+                  msg := parameters.message
+                }
+
+                violation[{"msg": msg, "details": {"missing_labels": missing}}] {
+                  input.review.object.metadata.name != "kube-root-ca.crt"
+                  input.review.object.metadata.name != "openshift-service-ca.crt"
+                  provided := {label | input.review.object.metadata.labels[label]}
+                  required := {label | label := input.parameters.labels[_].key}
+                  missing := required - provided
+                  count(missing) > 0
+                  def_msg := sprintf("you must provide labels: %v", [missing])
+                  msg := get_message(input.parameters, def_msg)
+                }
+
+                violation[{"msg": msg}] {
+                  input.review.object.metadata.name != "kube-root-ca.crt"
+                  input.review.object.metadata.name != "openshift-service-ca.crt"
+                  value := input.review.object.metadata.labels[key]
+                  expected := input.parameters.labels[_]
+                  expected.key == key
+                  # do not match if allowedRegex is not defined, or is an empty string
+                  expected.allowedRegex != ""
+                  not re_match(expected.allowedRegex, value)
+                  def_msg := sprintf("Label <%v: %v> does not satisfy allowed regex: %v", [key, value, expected.allowedRegex])
+                  msg := get_message(input.parameters, def_msg)
+                }
+    - objectDefinition:
+        apiVersion: constraints.gatekeeper.sh/v1beta1
+        kind: Case18ConstraintTemplate
+        metadata:
+          name: case18-gk-constraint
+        spec:
+          enforcementAction: dryrun
+          match:
+            kinds:
+              - apiGroups: [""]
+                kinds: ["ConfigMap"]
+            scope: Namespaced
+            namespaces:
+              - case18-gk-test
+          parameters:
+            message: "All configmaps must have a 'my-gk-test' label"
+            labels:
+            - key: "my-gk-test"


### PR DESCRIPTION
A new "controller" watches the Deployment for an uninstall annotation. When the annotation is true, it updates a flag so that all the other controllers don't have to track it individually. Most controllers just skip their reconciles during the uninstall, but the template-sync will clean up its finalizers (and skip an error case during that process).

The default behavior is still to run the controllers. But if the first command line argument is `trigger-uninstall`, then the process will add the uninstallation annotation to the controller's deployment, and delete all the policies on the cluster. The main intent of this is to be run as a pre-delete hook when uninstalling the addon.

https://issues.redhat.com/browse/ACM-3329