### PR TITLE
Make conflicted object template error more readable

### DIFF
--- a/controllers/templatesync/template_sync.go
+++ b/controllers/templatesync/template_sync.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -496,6 +497,17 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 
 				_, err = res.Create(ctx, tObjectUnstructured, metav1.CreateOptions{})
 				if err != nil {
+					multiTemplateRegExp := regexp.MustCompile(
+						`spec" must validate one and only one schema \(oneOf\)\. Found 2 valid alternatives$`,
+					)
+
+					if multiTemplateRegExp.MatchString(err.Error()) {
+						err = fmt.Errorf(
+							`ConfigurationPolicy.policy.open-cluster-management.io "%s" is invalid: `+
+								`spec may only contain one of object-templates and object-templates-raw`, tName,
+						)
+					}
+
 					resultError = err
 					errMsg := fmt.Sprintf("Failed to create policy template: %s", err)
 

--- a/test/e2e/case10_error_test.go
+++ b/test/e2e/case10_error_test.go
@@ -270,6 +270,20 @@ var _ = Describe("Test error handling", func() {
 			1,
 		).Should(BeTrue())
 	})
+	It("should throw a noncompliance event if the both object-templates and object-templates-raw are set", func() {
+		hubApplyPolicy("case10-obj-template-conflict",
+			yamlBasePath+"multiple-obj-template-arrays.yaml")
+
+		By("Checking for the error event")
+		Eventually(
+			checkForEvent(
+				"case10-obj-template-conflict",
+				"spec may only contain one of object-templates and object-templates-raw",
+			),
+			defaultTimeoutSeconds,
+			1,
+		).Should(BeTrue())
+	})
 })
 
 // Checks for an event on the managed cluster

--- a/test/resources/case10_template_sync_error_test/multiple-obj-template-arrays.yaml
+++ b/test/resources/case10_template_sync_error_test/multiple-obj-template-arrays.yaml
@@ -1,0 +1,41 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: case10-obj-template-conflict
+  labels:
+    policy.open-cluster-management.io/cluster-name: managed
+    policy.open-cluster-management.io/cluster-namespace: managed
+    policy.open-cluster-management.io/root-policy: case10-invalid-severity
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: case10-obj-template-conflict-cfgpol
+        spec:
+          remediationAction: inform
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Pod
+                metadata:
+                  name: nginx-pod-e2e
+                  namespace: default
+                spec:
+                  containers:
+                    - name: nginx
+          object-templates-raw: |
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Pod
+                metadata:
+                  name: nginx-pod-e2e
+                  namespace: default
+                spec:
+                  containers:
+                    - name: nginx


### PR DESCRIPTION
Replaces the error returned by the CRD for conflicting object-templates and object-templates-raw with a more readable one. There does not seem to be a way to add a custom error message for this failure in the CRD itself, so this change just watches for the error message and replaces it with a more readable one before the event is sent.

ref: https://issues.redhat.com/browse/ACM-4083