### PR TITLE
Get deployment name from environment variable

### DIFF
--- a/controllers/uninstall/watcher.go
+++ b/controllers/uninstall/watcher.go
@@ -10,11 +10,12 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"open-cluster-management.io/governance-policy-framework-addon/tool"
 )
 
 const (
 	ControllerName = "uninstall-watcher"
-	DeploymentName = "governance-policy-framework-addon"
 )
 
 var (
@@ -107,7 +108,7 @@ func StartWatcher(ctx context.Context, mgr manager.Manager, namespace string) er
 		Version:   "v1",
 		Kind:      "Deployment",
 		Namespace: namespace,
-		Name:      DeploymentName,
+		Name:      tool.Options.DeploymentName,
 	}
 
 	err = dynamicWatcher.AddOrUpdateWatcher(self, self)

--- a/deploy/manager/manager.yaml
+++ b/deploy/manager/manager.yaml
@@ -2,16 +2,17 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: governance-policy-framework-addon
+  labels:
+    app: governance-policy-framework-addon
 spec:
   replicas: 1
   selector:
     matchLabels:
-      name: governance-policy-framework-addon
+      app: governance-policy-framework-addon
   template:
     metadata:
       labels:
-        name: governance-policy-framework-addon
-        app: governance-policy-framework
+        app: governance-policy-framework-addon
     spec:
       securityContext:
         runAsNonRoot: true
@@ -38,6 +39,10 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: governance-policy-framework-addon
+            - name: DEPLOYMENT_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['app']
           securityContext:
             allowPrivilegeEscalation: false
           livenessProbe:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -206,18 +206,19 @@ subjects:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  labels:
+    app: governance-policy-framework-addon
   name: governance-policy-framework-addon
   namespace: open-cluster-management-agent-addon
 spec:
   replicas: 1
   selector:
     matchLabels:
-      name: governance-policy-framework-addon
+      app: governance-policy-framework-addon
   template:
     metadata:
       labels:
-        app: governance-policy-framework
-        name: governance-policy-framework-addon
+        app: governance-policy-framework-addon
     spec:
       containers:
       - args:
@@ -235,6 +236,10 @@ spec:
               fieldPath: metadata.name
         - name: OPERATOR_NAME
           value: governance-policy-framework-addon
+        - name: DEPLOYMENT_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['app']
         image: quay.io/open-cluster-management/governance-policy-framework-addon:latest
         imagePullPolicy: Always
         livenessProbe:

--- a/tool/options.go
+++ b/tool/options.go
@@ -4,6 +4,8 @@
 package tool
 
 import (
+	"os"
+
 	"github.com/spf13/pflag"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
@@ -25,6 +27,7 @@ type SyncerOptions struct {
 	// The namespace that the replicated policies should be synced to. This defaults to the same namespace as on the
 	// Hub.
 	ClusterNamespace string
+	DeploymentName   string
 }
 
 // Options default value
@@ -111,4 +114,11 @@ func ProcessFlags() {
 		"localhost:8383",
 		"The address the metrics endpoint binds to.",
 	)
+
+	Options.DeploymentName = os.Getenv("DEPLOYMENT_NAME")
+	if Options.DeploymentName == "" {
+		log.Info("Environment variable DEPLOYMENT_NAME is empty, using default 'governance-policy-framework-addon'")
+
+		Options.DeploymentName = "governance-policy-framework-addon"
+	}
 }


### PR DESCRIPTION
The environment variable will be populated from the labels on the pod, using the downward API.

Refs:
 - https://issues.redhat.com/browse/ACM-3329

Fixes problems found in https://github.com/open-cluster-management-io/governance-policy-addon-controller/pull/71, where the deployment name is different [in the addon-controller](https://github.com/open-cluster-management-io/governance-policy-addon-controller/blob/cce56fadef78a48b33524d1c99888de59c7ec7d7/pkg/addon/policyframework/manifests/managedclusterchart/templates/deployment.yaml#L6) than here... Looking back, hard-coding it here was not the best idea I've ever had.