### PR TITLE
Synchronously emit template events

### DIFF
--- a/controllers/gatekeepersync/gatekeeper_constraint_sync.go
+++ b/controllers/gatekeepersync/gatekeeper_constraint_sync.go
@@ -396,7 +396,9 @@ func (r *GatekeeperConstraintReconciler) sendComplianceEvent(
 			return nil
 		}
 
-		err := r.SendEvent(ctx, constraint, owner, msg, compliance)
+		reason := utils.EventReason(constraint.GetNamespace(), constraint.GetName())
+
+		err := r.SendEvent(ctx, constraint, owner, reason, msg, compliance)
 		if err != nil {
 			return err
 		}

--- a/controllers/templatesync/template_sync.go
+++ b/controllers/templatesync/template_sync.go
@@ -80,6 +80,7 @@ type PolicyReconciler struct {
 	Config              *rest.Config
 	Recorder            record.EventRecorder
 	ClusterNamespace    string
+	Clientset           *kubernetes.Clientset
 	DisableGkSync       bool
 	createdGkConstraint *bool
 }
@@ -135,8 +136,7 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 	var dClient dynamic.Interface
 
 	if len(instance.Spec.PolicyTemplates) > 0 {
-		clientset := kubernetes.NewForConfigOrDie(r.Config)
-		discoveryClient = clientset.Discovery()
+		discoveryClient = r.Clientset.Discovery()
 
 		// initialize dynamic client
 		dClient, err = dynamic.NewForConfig(r.Config)

--- a/main.go
+++ b/main.go
@@ -451,6 +451,8 @@ func getManager(
 		os.Exit(1)
 	}
 
+	instanceName, _ := os.Hostname() // on an error, instanceName will be empty, which is ok
+
 	templateReconciler := &templatesync.PolicyReconciler{
 		Client:           mgr.GetClient(),
 		DynamicWatcher:   watcher,
@@ -459,6 +461,7 @@ func getManager(
 		Recorder:         mgr.GetEventRecorderFor(templatesync.ControllerName),
 		ClusterNamespace: tool.Options.ClusterNamespace,
 		Clientset:        kubernetes.NewForConfigOrDie(mgr.GetConfig()),
+		InstanceName:     instanceName,
 		DisableGkSync:    tool.Options.DisableGkSync,
 	}
 

--- a/main.go
+++ b/main.go
@@ -458,6 +458,7 @@ func getManager(
 		Config:           mgr.GetConfig(),
 		Recorder:         mgr.GetEventRecorderFor(templatesync.ControllerName),
 		ClusterNamespace: tool.Options.ClusterNamespace,
+		Clientset:        kubernetes.NewForConfigOrDie(mgr.GetConfig()),
 		DisableGkSync:    tool.Options.DisableGkSync,
 	}
 

--- a/test/e2e/case12_ordering_test.go
+++ b/test/e2e/case12_ordering_test.go
@@ -13,6 +13,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 	"open-cluster-management.io/governance-policy-propagator/test/utils"
+
+	fwutils "open-cluster-management.io/governance-policy-framework-addon/controllers/utils"
 )
 
 // Helper function to create events
@@ -47,6 +49,7 @@ func generateEventOnPolicy(plcName string, cfgPlcName string, msg string, compli
 			Name:       managedPlc.GetName(),
 			UID:        managedPlc.GetUID(),
 		},
+		fwutils.EventReason(clusterNamespace, cfgPlcName),
 		msg,
 		policiesv1.ComplianceState(complianceState),
 	)


### PR DESCRIPTION
Main commit:

Previously, the controller-runtime event recorder was used for these events. Other policy controllers have moved away from that, for various reasons. In this case, if a policy went from pending to noncompliant and back to pending, the "old" pending event would be re-used by the event recorder, and only the `lastTimestamp` would be updated. In this case, if a policy controller emitted a compliance event within the same second as the Pending event, the status-sync would see it as a tie, and use the hex-encoded nanoseconds in the event name. But the event name was not updated from the original instance when the policy was pending, so the events would be ordered incorrectly.

Most error cases from this synchronous sending can be ignored because they are already error cases that would be requeued.

Refs:
 - https://issues.redhat.com/browse/ACM-4699
