### PR TITLE
Bug: Policy compliance status is truncated

### DIFF
--- a/controllers/utils/events.go
+++ b/controllers/utils/events.go
@@ -33,9 +33,6 @@ func (c *ComplianceEventSender) SendEvent(
 	compliance policyv1.ComplianceState,
 ) error {
 	msg = string(compliance) + "; " + msg
-	if len([]rune(msg)) > 1024 {
-		msg = string([]rune(msg)[:1021]) + "..."
-	}
 
 	now := time.Now()
 
@@ -61,7 +58,6 @@ func (c *ComplianceEventSender) SendEvent(
 		FirstTimestamp:      metav1.NewTime(now),
 		LastTimestamp:       metav1.NewTime(now),
 		Count:               1,
-		EventTime:           metav1.NewMicroTime(now),
 		Action:              "ComplianceStateUpdate",
 		ReportingController: c.ControllerName,
 		ReportingInstance:   c.InstanceName,


### PR DESCRIPTION
Description of problem:
The status message for non compliant policy is truncated with "..." when the policy has multiple objectTemplates or a namespace. This leaves the user unable to determine why the policy is non compliant.

Expect result:
Messges should not be truncated. Messages can be over 1024 in length