### PR TITLE
Update event to include real status

### DIFF
--- a/controllers/statussync/policy_status_sync.go
+++ b/controllers/statussync/policy_status_sync.go
@@ -418,8 +418,8 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 			}
 
 			r.HubRecorder.Event(hubPlc, "Normal", "PolicyStatusSync",
-				fmt.Sprintf("Policy %s status was updated in cluster namespace %s", hubPlc.GetName(),
-					hubPlc.GetNamespace()))
+				fmt.Sprintf("Policy %s status was updated to %s in cluster namespace %s", hubPlc.GetName(),
+					hubPlc.Status.ComplianceState, hubPlc.GetNamespace()))
 		} else {
 			reqLogger.Info("status match on hub, nothing to update")
 		}


### PR DESCRIPTION
for the global hub, we are going to show the policy compliance trend. It is very important to have real policy status in the events so that we can know the frequency of policy changing.

@mprahl Is the change OK? Thanks.