### PR TITLE
Bug: Creating two policy templates with the same name succeeds

### DIFF
--- a/controllers/templatesync/template_utils.go
+++ b/controllers/templatesync/template_utils.go
@@ -1,0 +1,20 @@
+package templatesync
+
+import (
+	"encoding/json"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// unmarshalFromJSON unmarshals raw JSON data into an object
+func unmarshalFromJSON(rawData []byte) (unstructured.Unstructured, error) {
+	var unstruct unstructured.Unstructured
+
+	if jsonErr := json.Unmarshal(rawData, &unstruct.Object); jsonErr != nil {
+		log.Error(jsonErr, "Could not unmarshal data from JSON")
+
+		return unstruct, jsonErr
+	}
+
+	return unstruct, nil
+}

--- a/test/resources/case10_template_sync_error_test/dup-name-policy.yaml
+++ b/test/resources/case10_template_sync_error_test/dup-name-policy.yaml
@@ -1,0 +1,52 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata: 
+  name: dup-policy
+  labels:
+    policy.open-cluster-management.io/cluster-name: managed
+    policy.open-cluster-management.io/cluster-namespace: managed
+    policy.open-cluster-management.io/root-policy: dup-policy
+spec: 
+  disabled: false
+  policy-templates: 
+    - objectDefinition: 
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata: 
+          name: policy-config-dup
+        spec: 
+          namespaceSelector: 
+            exclude: 
+              - kube-*
+            include: 
+              - default
+          object-templates: 
+            - complianceType: musthave
+              objectDefinition: 
+                apiVersion: v1
+                kind: Pod
+                metadata: 
+                  name: pod-2
+                spec: 
+                  containers: 
+                    - name: nginx
+                      image: nginx:1.18.0
+                      ports: 
+                        - containerPort: 80
+          remediationAction: inform
+          severity: low
+    - objectDefinition: 
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata: 
+          name: policy-config-dup
+        spec: 
+          object-templates: 
+            - complianceType: musthave
+              objectDefinition: 
+                apiVersion: v1
+                kind: Namespace
+                metadata: 
+                  name: my-namespace
+          remediationAction: inform
+          severity: low


### PR DESCRIPTION
Creating a policy with identical names succeeds. The ConfigurationPolicy is repeatedly overwritten by the template-sync, swapping out the two policies, and repeatedly updating the status with alternating statuses from the two policies.

For example, this policy has two ConfigurationPolicy templates both named policy-pod

Expect to fail and return a status that there is a duplicate name instead.

Ref: https://issues.redhat.com/browse/ACM-5724
Signed-off-by: Yi Rae Kim <yikim@redhat.com>