### PR TITLE
Remove ConfigMap permissions

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -11,18 +11,6 @@ metadata:
   namespace: open-cluster-management-agent-addon
 rules:
 - apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
   - coordination.k8s.io
   resources:
   - leases

--- a/deploy/rbac/leader_election_role.yaml
+++ b/deploy/rbac/leader_election_role.yaml
@@ -5,18 +5,6 @@ metadata:
   name: governance-policy-framework-addon-leader-election
 rules:
 - apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
   - coordination.k8s.io
   resources:
   - leases


### PR DESCRIPTION
ConfigMap permissions were only necessary for legacy leader election, which was removed.

ref: https://issues.redhat.com/browse/ACM-5042