### PR TITLE
Fix template sync duplicate detection

### DIFF
--- a/controllers/templatesync/template_sync.go
+++ b/controllers/templatesync/template_sync.go
@@ -1551,6 +1551,9 @@ func hasDupName(pol *policiesv1.Policy) bool {
 		}
 
 		name := unstructured.GetName()
+		apiv := unstructured.GetAPIVersion()
+		kind := unstructured.GetKind()
+		name = fmt.Sprintf("%s/%s/%s", name, apiv, kind)
 
 		if _, has := foundNames[name]; has {
 			return true


### PR DESCRIPTION
We don't want duplicate config policy templates, but the logic prevented me from having a Constraint and a ConstraintTemplate that had the same name.  Of course a config policy couldn't have that same name either so adding gvk in the name check.

Refs:
 - https://issues.redhat.com/browse/ACM-7265