### PR TITLE
Allow duplicate naming for different kinds

### DIFF
--- a/controllers/templatesync/template_sync.go
+++ b/controllers/templatesync/template_sync.go
@@ -367,6 +367,13 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 			continue
 		}
 
+		// if there's a duplicate name, append the kind since duplicates should only exist for different kinds
+		for _, tmpName := range templateNames {
+			if tmpName == tName {
+				tName = fmt.Sprintf("%s-%s", tName, strings.ToLower(object.GetObjectKind().GroupVersionKind().Kind))
+			}
+		}
+
 		templateNames = append(templateNames, tName)
 
 		tLogger := reqLogger.WithValues("template", tName)

--- a/test/resources/case17_gatekeeper_sync/case17-gk-constraint-naming.yaml
+++ b/test/resources/case17_gatekeeper_sync/case17-gk-constraint-naming.yaml
@@ -1,0 +1,17 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: Case17ResourceNaming
+metadata:
+  name: case17resourcenaming
+spec:
+  enforcementAction: warn
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["ConfigMap"]
+    scope: Namespaced
+    namespaces:
+      - case17-gk-test
+  parameters:
+    message: "All configmaps must have a 'my-gk-test' label"
+    labels:
+    - key: "my-gk-test"

--- a/test/resources/case17_gatekeeper_sync/case17-gk-policy-naming.yaml
+++ b/test/resources/case17_gatekeeper_sync/case17-gk-policy-naming.yaml
@@ -1,0 +1,103 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: case17resourcenaming
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: templates.gatekeeper.sh/v1
+        kind: ConstraintTemplate
+        metadata:
+          name: case17resourcenaming
+          annotations:
+            metadata.gatekeeper.sh/title: "Required Labels"
+            metadata.gatekeeper.sh/version: 1.0.0
+            description: >-
+              Requires resources to contain specified labels, with values matching
+              provided regular expressions.
+        spec:
+          crd:
+            spec:
+              names:
+                kind: Case17ResourceNaming
+              validation:
+                legacySchema: false
+                openAPIV3Schema:
+                  type: object
+                  properties:
+                    message:
+                      type: string
+                    labels:
+                      type: array
+                      description: >-
+                        A list of labels and values the object must specify.
+                      items:
+                        type: object
+                        properties:
+                          key:
+                            type: string
+                            description: >-
+                              The required label.
+                          allowedRegex:
+                            type: string
+                            description: >-
+                              If specified, a regular expression the annotation's value
+                              must match. The value must contain at least one match for
+                              the regular expression.
+          targets:
+            - target: admission.k8s.gatekeeper.sh
+              rego: |
+                package k8srequiredlabels
+
+                get_message(parameters, _default) = msg {
+                  not parameters.message
+                  msg := _default
+                }
+
+                get_message(parameters, _default) = msg {
+                  msg := parameters.message
+                }
+
+                violation[{"msg": msg, "details": {"missing_labels": missing}}] {
+                  input.review.object.metadata.name != "kube-root-ca.crt"
+                  input.review.object.metadata.name != "openshift-service-ca.crt"
+                  provided := {label | input.review.object.metadata.labels[label]}
+                  required := {label | label := input.parameters.labels[_].key}
+                  missing := required - provided
+                  count(missing) > 0
+                  def_msg := sprintf("you must provide labels: %v", [missing])
+                  msg := get_message(input.parameters, def_msg)
+                }
+
+                violation[{"msg": msg}] {
+                  input.review.object.metadata.name != "kube-root-ca.crt"
+                  input.review.object.metadata.name != "openshift-service-ca.crt"
+                  value := input.review.object.metadata.labels[key]
+                  expected := input.parameters.labels[_]
+                  expected.key == key
+                  # do not match if allowedRegex is not defined, or is an empty string
+                  expected.allowedRegex != ""
+                  not re_match(expected.allowedRegex, value)
+                  def_msg := sprintf("Label <%v: %v> does not satisfy allowed regex: %v", [key, value, expected.allowedRegex])
+                  msg := get_message(input.parameters, def_msg)
+                }
+    - objectDefinition:
+        apiVersion: constraints.gatekeeper.sh/v1beta1
+        kind: Case17ResourceNaming
+        metadata:
+          name: case17resourcenaming
+        spec:
+          enforcementAction: dryrun
+          match:
+            kinds:
+              - apiGroups: [""]
+                kinds: ["ConfigMap"]
+            scope: Namespaced
+            namespaces:
+              - case17-gk-test
+          parameters:
+            message: "All configmaps must have a 'my-gk-test' label"
+            labels:
+            - key: "my-gk-test"

--- a/test/resources/case17_gatekeeper_sync/case17constrainttemplatenaming.yaml
+++ b/test/resources/case17_gatekeeper_sync/case17constrainttemplatenaming.yaml
@@ -1,0 +1,76 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: case17resourcenaming
+  annotations:
+    metadata.gatekeeper.sh/title: "Required Labels"
+    metadata.gatekeeper.sh/version: 1.0.0
+    description: >-
+      Requires resources to contain specified labels, with values matching
+      provided regular expressions.
+spec:
+  crd:
+    spec:
+      names:
+        kind: Case17ResourceNaming
+      validation:
+        legacySchema: false
+        openAPIV3Schema:
+          type: object
+          properties:
+            message:
+              type: string
+            labels:
+              type: array
+              description: >-
+                A list of labels and values the object must specify.
+              items:
+                type: object
+                properties:
+                  key:
+                    type: string
+                    description: >-
+                      The required label.
+                  allowedRegex:
+                    type: string
+                    description: >-
+                      If specified, a regular expression the annotation's value
+                      must match. The value must contain at least one match for
+                      the regular expression.
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package k8srequiredlabels
+
+        get_message(parameters, _default) = msg {
+          not parameters.message
+          msg := _default
+        }
+
+        get_message(parameters, _default) = msg {
+          msg := parameters.message
+        }
+
+        violation[{"msg": msg, "details": {"missing_labels": missing}}] {
+          input.review.object.metadata.name != "kube-root-ca.crt"
+          input.review.object.metadata.name != "openshift-service-ca.crt"
+          provided := {label | input.review.object.metadata.labels[label]}
+          required := {label | label := input.parameters.labels[_].key}
+          missing := required - provided
+          count(missing) > 0
+          def_msg := sprintf("you must provide labels: %v", [missing])
+          msg := get_message(input.parameters, def_msg)
+        }
+
+        violation[{"msg": msg}] {
+          input.review.object.metadata.name != "kube-root-ca.crt"
+          input.review.object.metadata.name != "openshift-service-ca.crt"
+          value := input.review.object.metadata.labels[key]
+          expected := input.parameters.labels[_]
+          expected.key == key
+          # do not match if allowedRegex is not defined, or is an empty string
+          expected.allowedRegex != ""
+          not re_match(expected.allowedRegex, value)
+          def_msg := sprintf("Label <%v: %v> does not satisfy allowed regex: %v", [key, value, expected.allowedRegex])
+          msg := get_message(input.parameters, def_msg)
+        }


### PR DESCRIPTION
You can't have duplicate policy templates since they will show in the console with the same name and can't be distinguished.  This PR is to allow a constraint and constraint template to have the same name and use the kind to distinguish them.

Refs:
 - https://issues.redhat.com/browse/ACM-7566