### PR TITLE
Fix RegEx to allow any character in a template name

### DIFF
--- a/controllers/statussync/policy_status_sync.go
+++ b/controllers/statussync/policy_status_sync.go
@@ -184,7 +184,7 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 	// filter events to current policy instance and build map
 	eventForPolicyMap := make(map[string]*[]historyEvent)
 	// panic if regexp invalid
-	rgx := regexp.MustCompile(`(?i)^policy:\s*(?:([a-z0-9.-]+)\s*\/)?([a-z0-9.-]+)`)
+	rgx := regexp.MustCompile(`(?i)^policy:\s*(?:([a-z0-9.-]+)\s*\/)?(.+)`)
 	for _, event := range eventList.Items {
 		// sample event.Reason -- reason: 'policy: calamari/policy-grc-rbactest-example'
 		reason := rgx.FindString(event.Reason)

--- a/test/resources/case10_template_sync_error_test/invalid-name-error.yaml
+++ b/test/resources/case10_template_sync_error_test/invalid-name-error.yaml
@@ -1,0 +1,30 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: case10-invalid-name-error
+  labels:
+    policy.open-cluster-management.io/cluster-name: managed
+    policy.open-cluster-management.io/cluster-namespace: managed
+    policy.open-cluster-management.io/root-policy: case10-template-name-error
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: case10_invalid-name
+        spec:
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Pod
+                metadata:
+                  name: nginx-pod-e2e
+                  namespace: default
+                spec:
+                  containers:
+                    - name: nginx
+


### PR DESCRIPTION
If an invalid character is provided in a template name, our RegEx was filtering it out and not handling it properly.

I'm not sure whether this is too broad and we might need something like non-whitespace `^\s` or non-forward-slash `^/`, but technically a user can put whatever they want in there, so it seemed like `.` might be most appropriate.

ref: https://issues.redhat.com/browse/ACM-7737