### PR TITLE
Add back name label to deployment

### DIFF
--- a/deploy/manager/kustomization.yaml
+++ b/deploy/manager/kustomization.yaml
@@ -1,7 +1,5 @@
 namespace: open-cluster-management-agent-addon
 
-bases:
-  - ../rbac
-
 resources:
+  - ../rbac
   - manager.yaml

--- a/deploy/manager/manager.yaml
+++ b/deploy/manager/manager.yaml
@@ -13,6 +13,7 @@ spec:
     metadata:
       labels:
         app: governance-policy-framework-addon
+        name: governance-policy-framework-addon
     spec:
       securityContext:
         runAsNonRoot: true

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -207,6 +207,7 @@ spec:
     metadata:
       labels:
         app: governance-policy-framework-addon
+        name: governance-policy-framework-addon
     spec:
       containers:
       - args:


### PR DESCRIPTION
This is used for debug log collection by the framework.

Reverts change in https://github.com/open-cluster-management-io/governance-policy-framework-addon/pull/51

/cc @JustinKuli 