### PR TITLE
Undo the template duplication check update

### DIFF
--- a/controllers/templatesync/template_sync.go
+++ b/controllers/templatesync/template_sync.go
@@ -1556,9 +1556,6 @@ func hasDupName(pol *policiesv1.Policy) bool {
 		}
 
 		name := unstructured.GetName()
-		apiv := unstructured.GetAPIVersion()
-		kind := unstructured.GetKind()
-		name = fmt.Sprintf("%s/%s/%s", name, apiv, kind)
 
 		if _, has := foundNames[name]; has {
 			return true

--- a/controllers/templatesync/template_sync_test.go
+++ b/controllers/templatesync/template_sync_test.go
@@ -133,7 +133,7 @@ func TestHasDuplicateNames(t *testing.T) {
 
 	has := hasDupName(&policy)
 	if has {
-		t.Fatal("Duplicate names found in templates but not expected")
+		t.Fatal("Unexpected duplicate policy template names")
 	}
 
 	// add a gatekeeper constraint template with a duplicate name
@@ -161,8 +161,8 @@ func TestHasDuplicateNames(t *testing.T) {
 	policy.Spec.PolicyTemplates = append(policy.Spec.PolicyTemplates, &y)
 
 	has = hasDupName(&policy)
-	if has {
-		t.Fatal("Duplicate names found in templates but not expected")
+	if !has {
+		t.Fatal("Duplicate names for templates not detected")
 	}
 
 	// add a gatekeeper constraint with a duplicate name
@@ -190,8 +190,8 @@ func TestHasDuplicateNames(t *testing.T) {
 	policy.Spec.PolicyTemplates = append(policy.Spec.PolicyTemplates, &z)
 
 	has = hasDupName(&policy)
-	if has {
-		t.Fatal("Duplicate names found in templates but not expected")
+	if !has {
+		t.Fatal("Duplicate names for templates not detected")
 	}
 
 	// add a config policy with a duplicate name


### PR DESCRIPTION
The template name duplications could be an issue with users managing lots of templates and there being a requirement no names can conflict. To avoid having duplicate names there would need to be additional fields in the status which I don't want to add unless we have a customer RFE. This update removes a previous change.

Refs:
 - https://issues.redhat.com/browse/ACM-7265
 - https://issues.redhat.com/browse/ACM-7566