### PR TITLE
Enable concurrent reconciles, QPS, and burst configurations

### DIFF
--- a/controllers/gatekeepersync/gatekeeper_constraint_sync.go
+++ b/controllers/gatekeepersync/gatekeeper_constraint_sync.go
@@ -48,7 +48,7 @@ func (r *GatekeeperConstraintReconciler) SetupWithManager(mgr ctrl.Manager, cons
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&policyv1.Policy{}).
 		WithEventFilter(policyPredicates()).
-		WithOptions(controller.Options{MaxConcurrentReconciles: 5}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: r.ConcurrentReconciles}).
 		WatchesRawSource(constraintEvents, &handler.EnqueueRequestForObject{}).
 		Named(ControllerName).
 		Complete(r)
@@ -74,7 +74,8 @@ type GatekeeperConstraintReconciler struct {
 	ConstraintsWatcher depclient.DynamicWatcher
 	// A cache of sent messages to avoid repeating status events due to race conditions. Each value is a SHA1
 	// digest.
-	lastSentMessages sync.Map
+	lastSentMessages     sync.Map
+	ConcurrentReconciles int
 }
 
 //+kubebuilder:rbac:groups=policy.open-cluster-management.io,resources=policies,verbs=get;list;watch

--- a/controllers/secretsync/secret_sync.go
+++ b/controllers/secretsync/secret_sync.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -34,6 +35,7 @@ func (r *SecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&corev1.Secret{}).
 		Named(ControllerName).
+		WithOptions(controller.Options{MaxConcurrentReconciles: r.ConcurrentReconciles}).
 		Complete(r)
 }
 
@@ -45,7 +47,8 @@ type SecretReconciler struct {
 	ManagedClient client.Client
 	Scheme        *runtime.Scheme
 	// The namespace that the secret should be synced to.
-	TargetNamespace string
+	TargetNamespace      string
+	ConcurrentReconciles int
 }
 
 // WARNING: In production, this should be namespaced to the actual managed cluster namespace.

--- a/controllers/specsync/policy_spec_sync.go
+++ b/controllers/specsync/policy_spec_sync.go
@@ -17,6 +17,7 @@ import (
 	"open-cluster-management.io/governance-policy-propagator/controllers/common"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -33,6 +34,7 @@ func (r *PolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&policiesv1.Policy{}).
 		Named(ControllerName).
+		WithOptions(controller.Options{MaxConcurrentReconciles: r.ConcurrentReconciles}).
 		Complete(r)
 }
 
@@ -48,7 +50,8 @@ type PolicyReconciler struct {
 	ManagedRecorder record.EventRecorder
 	Scheme          *runtime.Scheme
 	// The namespace that the replicated policies should be synced to.
-	TargetNamespace string
+	TargetNamespace      string
+	ConcurrentReconciles int
 }
 
 //+kubebuilder:rbac:groups=policy.open-cluster-management.io,resources=policies,verbs=create;delete;get;list;patch;update;watch

--- a/controllers/statussync/policy_status_sync.go
+++ b/controllers/statussync/policy_status_sync.go
@@ -26,6 +26,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -46,6 +47,7 @@ func (r *PolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			handler.EnqueueRequestsFromMapFunc(eventMapper),
 			builder.WithPredicates(eventPredicateFuncs),
 		).
+		WithOptions(controller.Options{MaxConcurrentReconciles: r.ConcurrentReconciles}).
 		Named(ControllerName).
 		Complete(r)
 }
@@ -63,6 +65,7 @@ type PolicyReconciler struct {
 	ManagedRecorder       record.EventRecorder
 	Scheme                *runtime.Scheme
 	ClusterNamespaceOnHub string
+	ConcurrentReconciles  int
 }
 
 //+kubebuilder:rbac:groups=policy.open-cluster-management.io,resources=policies,verbs=get;list;watch;create;update;patch;delete

--- a/controllers/templatesync/template_sync.go
+++ b/controllers/templatesync/template_sync.go
@@ -36,6 +36,7 @@ import (
 	"open-cluster-management.io/governance-policy-propagator/controllers/common"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -65,6 +66,7 @@ func (r *PolicyReconciler) Setup(mgr ctrl.Manager, depEvents *source.Channel) er
 		Named(ControllerName).
 		For(&policiesv1.Policy{}).
 		WithEventFilter(templatePredicates()).
+		WithOptions(controller.Options{MaxConcurrentReconciles: r.ConcurrentReconciles}).
 		WatchesRawSource(depEvents, &handler.EnqueueRequestForObject{}).
 		Complete(r)
 }
@@ -77,15 +79,16 @@ type PolicyReconciler struct {
 	// This client, initialized using mgr.Client() above, is a split client
 	// that reads objects from the cache and writes to the apiserver
 	client.Client
-	DynamicWatcher      depclient.DynamicWatcher
-	Scheme              *runtime.Scheme
-	Config              *rest.Config
-	Recorder            record.EventRecorder
-	ClusterNamespace    string
-	Clientset           *kubernetes.Clientset
-	InstanceName        string
-	DisableGkSync       bool
-	createdGkConstraint *bool
+	DynamicWatcher       depclient.DynamicWatcher
+	Scheme               *runtime.Scheme
+	Config               *rest.Config
+	Recorder             record.EventRecorder
+	ClusterNamespace     string
+	Clientset            *kubernetes.Clientset
+	InstanceName         string
+	DisableGkSync        bool
+	createdGkConstraint  *bool
+	ConcurrentReconciles int
 }
 
 // Reconcile reads that state of the cluster for a Policy object and makes changes based on the state read


### PR DESCRIPTION
To allow configuration for concurrent reconciles, QPS, and burst, the following changes are proposed:
- Each reconciler struct for all controllers will require an extra field called `ConcurrentReconciles`, which is exposed in main and set to the value specified in the arguments passed to the framework addon.
- The `ConcurrentReconcile` field will be used when the set up between controller and manager occurs
-  QPS and burst are also parsed from controller arguments passed to the framework addon, and override default QPS and burst values from controller-runtime after the hub and managed configs are created.

ref: https://issues.redhat.com/browse/ACM-6711