### PR TITLE
Update log calls to be more consistent

### DIFF
--- a/controllers/gatekeepersync/gatekeeper_constraint_sync.go
+++ b/controllers/gatekeepersync/gatekeeper_constraint_sync.go
@@ -112,7 +112,7 @@ func (r *GatekeeperConstraintReconciler) Reconcile(
 	err := r.Get(ctx, request.NamespacedName, policy)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
-			log.V(1).Info("The Policy was deleted. Cleaning up watchers and status message cache.")
+			log.Info("The Policy was deleted. Cleaning up watchers and status message cache.")
 
 			r.lastSentMessages.Range(func(key, value any) bool {
 				keyTyped := key.(policyKindName)

--- a/controllers/specsync/policy_spec_sync.go
+++ b/controllers/specsync/policy_spec_sync.go
@@ -72,7 +72,7 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 	)
 
 	if uninstall.DeploymentIsUninstalling {
-		log.Info("Skipping reconcile because the deployment is in uninstallation mode")
+		reqLogger.Info("Skipping reconcile because the deployment is in uninstallation mode")
 
 		return reconcile.Result{RequeueAfter: 5 * time.Minute}, nil
 	}
@@ -101,6 +101,8 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 
 			if err != nil && !errors.IsNotFound(err) {
 				reqLogger.Error(err, "Failed to remove policy on managed cluster...")
+
+				return reconcile.Result{}, err
 			}
 
 			reqLogger.Info("Policy has been removed from managed cluster...Reconciliation complete.")

--- a/controllers/statussync/eventMapper.go
+++ b/controllers/statussync/eventMapper.go
@@ -5,7 +5,6 @@ package statussync
 
 import (
 	"context"
-	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -17,13 +16,9 @@ func eventMapper(_ context.Context, obj client.Object) []reconcile.Request {
 	//nolint:forcetypeassert
 	event := obj.(*corev1.Event)
 
-	log.Info(
-		fmt.Sprintf(
-			"Reconcile Request for Event %s in namespace %s",
-			event.GetName(),
-			event.GetNamespace(),
-		),
-	)
+	log := log.WithValues("eventName", event.GetName(), "eventNamespace", event.GetNamespace())
+
+	log.V(2).Info("Reconcile Request")
 
 	var result []reconcile.Request
 
@@ -32,13 +27,8 @@ func eventMapper(_ context.Context, obj client.Object) []reconcile.Request {
 		Namespace: event.InvolvedObject.Namespace,
 	}}
 
-	log.Info(
-		fmt.Sprintf(
-			"Queue event for Policy %s in namespace %s",
-			event.InvolvedObject.Name,
-			event.InvolvedObject.Namespace,
-		),
-	)
+	log.V(2).Info("Queueing event", "involvedName", event.InvolvedObject.Name,
+		"involvedNamespace", event.InvolvedObject.Namespace)
 
 	return append(result, request)
 }

--- a/controllers/templatesync/template_sync.go
+++ b/controllers/templatesync/template_sync.go
@@ -222,7 +222,7 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 	}
 
 	if uninstall.DeploymentIsUninstalling {
-		log.Info("Skipping reconcile because the deployment is in uninstallation mode")
+		reqLogger.Info("Skipping reconcile because the deployment is in uninstallation mode")
 
 		return reconcile.Result{RequeueAfter: 5 * time.Minute}, nil
 	}


### PR DESCRIPTION
I was looking at this for ACM-7778, but I don't think that the logs here are particularly noisy - since the controller is event driven, knowing when it starts reconciling something (for example) can be quite useful. Instead, this PR just ensures that the controller's log messages are consistently formatted.