### PR TITLE
Fix test panic

### DIFF
--- a/test/e2e/case22_user_validation_error_test.go
+++ b/test/e2e/case22_user_validation_error_test.go
@@ -59,7 +59,11 @@ var _ = Describe("Test proper metrics handling on syntax error", Ordered, func()
 				defaultTimeoutSeconds)
 			err := runtime.DefaultUnstructuredConverter.FromUnstructured(managedPlc.Object, &plc)
 			g.Expect(err).ToNot(HaveOccurred())
-			if len(plc.Status.Details) < 1 {
+			if len(plc.Status.Details) < 2 {
+				return ""
+			}
+
+			if len(plc.Status.Details[1].History) < 1 {
 				return ""
 			}
 


### PR DESCRIPTION
Hit a panic with "index out of bounds". Also bumps the length of the Details array to the correct threshold.

ref: https://github.com/stolostron/governance-policy-framework-addon/actions/runs/6809803804/job/18516791082?pr=207