### PR TITLE
Use SA for E2E

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -67,10 +67,15 @@ jobs:
       run: |
         make kind-bootstrap-cluster-dev
 
+    - name: Ensure Service Account kubeconfig
+      run: |
+        KUBECONFIG=${PWD}/kubeconfig_managed make kind-ensure-sa
+        KUBECONFIG=${PWD}/kubeconfig_hub make kind-ensure-sa
+
     - name: E2E Tests
       run: |
         export GOPATH=$(go env GOPATH)
-        make e2e-test-coverage
+        KUBECONFIG=${PWD}/kubeconfig_managed make e2e-test-coverage
 
     - name: E2E Tests That Simulate Hosted Mode
       run: |
@@ -79,17 +84,17 @@ jobs:
         export E2E_CLUSTER_NAMESPACE="other-namespace"
         export E2E_CLUSTER_NAMESPACE_ON_HUB="other-namespace-on-hub"
         export COVERAGE_E2E_OUT=coverage_e2e_hosted_mode.out
-        make e2e-test-coverage
+        KUBECONFIG=${PWD}/kubeconfig_managed make e2e-test-coverage
 
     - name: Verify Deployment Configuration
       run: |
         make build-images
-        make kind-deploy-controller-dev
+        KUBECONFIG=${PWD}/kubeconfig_managed_e2e make kind-deploy-controller-dev
 
     - name: Run E2E Uninstallation Tests
       if: ${{ matrix.kind == 'latest' }}
       run: |
-        make e2e-test-uninstall-coverage
+        KUBECONFIG=${PWD}/kubeconfig_managed make e2e-test-uninstall-coverage
 
     - name: Test Coverage Verification
       if: ${{ github.event_name == 'pull_request' && matrix.kind == 'latest' }}

--- a/build/common/Makefile.common.mk
+++ b/build/common/Makefile.common.mk
@@ -140,7 +140,7 @@ kind-ensure-sa:
 
 .PHONY: kind-controller-kubeconfig
 kind-controller-kubeconfig: install-resources
-	kubectl -n $(CONTROLLER_NAMESPACE) apply -f test/resources/e2e_controller_secret.yaml
+	kubectl -n $(CONTROLLER_NAMESPACE) apply -f test/resources/e2e_controller_secret.yaml --kubeconfig=$(PWD)/kubeconfig_$(CLUSTER_NAME)_e2e
 	-rm kubeconfig_$(CLUSTER_NAME)
 	@kubectl config set-cluster $(KIND_CLUSTER_NAME) --kubeconfig=$(PWD)/kubeconfig_$(CLUSTER_NAME) \
 		--server=$(shell kubectl config view --minify -o jsonpath='{.clusters[].cluster.server}' --kubeconfig=kubeconfig_$(CLUSTER_NAME)_e2e) \

--- a/controllers/secretsync/secret_sync.go
+++ b/controllers/secretsync/secret_sync.go
@@ -53,7 +53,7 @@ type SecretReconciler struct {
 
 // WARNING: In production, this should be namespaced to the actual managed cluster namespace.
 //+kubebuilder:rbac:groups=core,resources=secrets,verbs=create
-//+kubebuilder:rbac:groups=core,resources=secrets,resourceNames=policy-encryption-key,verbs=delete;get;update;list
+//+kubebuilder:rbac:groups=core,resources=secrets,resourceNames=policy-encryption-key,verbs=delete;get;update;list;watch
 
 // Reconcile handles updates to the "policy-encryption-key" Secret in the managed cluster namespace on the Hub.
 // The method is responsible for synchronizing the Secret to the managed cluster namespace on the managed cluster.

--- a/controllers/uninstall/triggeruninstall.go
+++ b/controllers/uninstall/triggeruninstall.go
@@ -32,6 +32,8 @@ var triggerLog = ctrl.Log.WithName("trigger-uninstall")
 
 const AnnotationKey = "policy.open-cluster-management.io/uninstalling"
 
+//+kubebuilder:rbac:groups=policy.open-cluster-management.io,resources=policies,verbs=deletecollection;
+
 // Trigger adds the uninstallation annotation to the Deployment, then deletes all the policies.
 // It will return nil only when all the policies are gone.
 // It takes command line arguments to configure itself.

--- a/deploy/hubpermissions/kustomization.yaml
+++ b/deploy/hubpermissions/kustomization.yaml
@@ -1,0 +1,4 @@
+namespace: open-cluster-management-agent-addon
+
+resources:
+  - ../rbac

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -113,6 +113,7 @@ rules:
   - get
   - list
   - update
+  - watch
 - apiGroups:
   - policy.open-cluster-management.io
   resources:
@@ -132,6 +133,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch

--- a/deploy/rbac/role.yaml
+++ b/deploy/rbac/role.yaml
@@ -83,6 +83,7 @@ rules:
   - get
   - list
   - update
+  - watch
 - apiGroups:
   - policy.open-cluster-management.io
   resources:
@@ -102,6 +103,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch

--- a/deploy/rbac/service_account.yaml
+++ b/deploy/rbac/service_account.yaml
@@ -2,3 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: governance-policy-framework-addon
+  namespace: open-cluster-management-agent-addon

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -72,11 +72,11 @@ func init() {
 	ctrl.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 	flag.StringVar(
 		&kubeconfigHub,
-		"kubeconfig_hub", "../../kubeconfig_hub",
+		"kubeconfig_hub", "../../kubeconfig_hub_e2e",
 		"Location of the kubeconfig to use; defaults to KUBECONFIG if not set")
 	flag.StringVar(
 		&kubeconfigManaged,
-		"kubeconfig_managed", "../../kubeconfig_managed",
+		"kubeconfig_managed", "../../kubeconfig_managed_e2e",
 		"Location of the kubeconfig to use; defaults to KUBECONFIG if not set")
 }
 
@@ -245,13 +245,13 @@ func LoadConfig(url, kubeconfig, context string) (*rest.Config, error) {
 }
 
 func kubectlHub(args ...string) (string, error) {
-	args = append(args, "--kubeconfig=../../kubeconfig_hub")
+	args = append(args, "--kubeconfig=../../kubeconfig_hub_e2e")
 
 	return propagatorutils.KubectlWithOutput(args...)
 }
 
 func kubectlManaged(args ...string) (string, error) {
-	args = append(args, "--kubeconfig=../../kubeconfig_managed")
+	args = append(args, "--kubeconfig=../../kubeconfig_managed_e2e")
 
 	return propagatorutils.KubectlWithOutput(args...)
 }

--- a/test/resources/e2e_controller_secret.yaml
+++ b/test/resources/e2e_controller_secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/service-account-token
+metadata:
+  name: governance-policy-framework-addon
+  annotations:
+    kubernetes.io/service-account.name: governance-policy-framework-addon


### PR DESCRIPTION
Changes:
- Create service accounts and related resources on both the hub and managed cluster
- Create separate kubeconfig files to be used for the controller and E2E tests
- Utilize the common makefile when bootstrapping clusters

ref: https://issues.redhat.com/browse/ACM-3301