### PR TITLE
Handle policy dependencies of Gatekeeper types

### DIFF
--- a/test/resources/case17_gatekeeper_sync/case17-gk-dep-on-constraint.yaml
+++ b/test/resources/case17_gatekeeper_sync/case17-gk-dep-on-constraint.yaml
@@ -1,0 +1,32 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: case17-gk-dep-on-constraint
+spec:
+  remediationAction: inform
+  disabled: false
+  dependencies:
+    - apiVersion: constraints.gatekeeper.sh/v1beta1
+      kind: Case17ConstraintTemplate
+      name: case17-gk-constraint
+      namespace: ""
+      compliance: Compliant
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: case17-gk-dep-on-constraint
+        spec:
+          remediationAction: inform
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Pod
+                metadata:
+                  name: nginx-pod-e2e
+                  namespace: default
+                spec:
+                  containers:
+                    - name: nginx

--- a/test/resources/case17_gatekeeper_sync/case17-gk-dep-on-tmpl.yaml
+++ b/test/resources/case17_gatekeeper_sync/case17-gk-dep-on-tmpl.yaml
@@ -1,0 +1,32 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: case17-gk-dep-on-tmpl
+spec:
+  remediationAction: inform
+  disabled: false
+  dependencies:
+    - apiVersion: templates.gatekeeper.sh/v1
+      kind: ConstraintTemplate
+      name: case17constrainttemplate
+      namespace: ""
+      compliance: Compliant
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: case17-gk-dep-on-tmpl
+        spec:
+          remediationAction: inform
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Pod
+                metadata:
+                  name: nginx-pod-e2e
+                  namespace: default
+                spec:
+                  containers:
+                    - name: nginx


### PR DESCRIPTION
Originally, policy dependencies could only handle objects that had a `status.complianceState` field. Gatekeeper ConstraintTemplates and Constraints do not have this field, but we assign them a compliance in a similar way elsewhere. This commit allows these Gatekeeper types to be used for policy dependencies like a user might expect.

Refs:
 - https://issues.redhat.com/browse/ACM-8998