### PR TITLE
Use token authentication for the compliance history API

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -113,6 +113,14 @@ rules:
 - apiGroups:
   - ""
   resourceNames:
+  - open-cluster-management-compliance-history-api-recorder
+  resources:
+  - secrets
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resourceNames:
   - policy-encryption-key
   resources:
   - secrets

--- a/deploy/rbac/role.yaml
+++ b/deploy/rbac/role.yaml
@@ -83,6 +83,14 @@ rules:
 - apiGroups:
   - ""
   resourceNames:
+  - open-cluster-management-compliance-history-api-recorder
+  resources:
+  - secrets
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resourceNames:
   - policy-encryption-key
   resources:
   - secrets


### PR DESCRIPTION
Related to https://github.com/open-cluster-management-io/governance-policy-addon-controller/pull/133

The addon framework's hub kubeconfig is certificate based. This does not allow authentication to the compliance history API using an OpenShift route that handles the TLS. Because of this, token based authentication is required.

This uses the hub kubeconfig's token first and if not set, falls back to getting the token from a secret in the cluster namespace on the Hub created by the policy addon controller.

Relates:
https://issues.redhat.com/browse/ACM-6889