### PR TITLE
Stop retrying to record invalid compliance events

### DIFF
--- a/controllers/statussync/policy_status_sync.go
+++ b/controllers/statussync/policy_status_sync.go
@@ -716,6 +716,19 @@ func StartComplianceEventsSyncer(
 				}
 			}
 
+			// If it's a bad request, then the database experienced data loss and the database ID is no longer valid.
+			if httpResponse.StatusCode == http.StatusBadRequest {
+				log.V(0).Info(
+					"Failed to record the compliance event with the compliance API. Will not requeue.",
+					"statusCode", httpResponse.StatusCode,
+					"message", message,
+				)
+				events.Forget(ceUntyped)
+				events.Done(ceUntyped)
+
+				continue
+			}
+
 			log.Info(
 				"Failed to record the compliance event with the compliance API. Will requeue.",
 				"statusCode", httpResponse.StatusCode,


### PR DESCRIPTION
This is to account for the database IDs being invalid due to data loss in the database. This is not recoverable so stop retrying forever.

Relates:
https://issues.redhat.com/browse/ACM-10109