### PR TITLE
Record compliance events in the compliance history API with nanoseconds

### DIFF
--- a/controllers/statussync/policy_status_sync_test.go
+++ b/controllers/statussync/policy_status_sync_test.go
@@ -1,0 +1,20 @@
+// Copyright Contributors to the Open Cluster Management project
+package statussync
+
+import (
+	"testing"
+)
+
+func TestParseTimestampFromEventName(t *testing.T) {
+	output, err := parseTimestampFromEventName("event.17b80d88a995e12c")
+	if err != nil {
+		t.Errorf("Expected no error but got: %v", err)
+	} else if output.Time.UnixNano() != 1709130939198988588 {
+		t.Errorf("Expected 1709130939198988588 but got: %d", output.Time.UnixNano())
+	}
+
+	output, err = parseTimestampFromEventName("event.with-no-timestamp")
+	if err == nil {
+		t.Errorf("Expected an error but got none: %s", output)
+	}
+}

--- a/test/e2e/case23_compliance_api_recording_test.go
+++ b/test/e2e/case23_compliance_api_recording_test.go
@@ -154,11 +154,8 @@ var _ = Describe("Compliance API recording", Ordered, Label("compliance-events-a
 	})
 
 	AfterAll(func(ctx context.Context) {
-		err := server.Shutdown(ctx)
-		Expect(err).ToNot(HaveOccurred())
-
 		By("Deleting a policy on hub cluster in ns:" + clusterNamespaceOnHub)
-		_, err = kubectlHub("delete", "-f", yamlPath, "-n", clusterNamespaceOnHub, "--ignore-not-found")
+		_, err := kubectlHub("delete", "-f", yamlPath, "-n", clusterNamespaceOnHub, "--ignore-not-found")
 		Expect(err).ToNot(HaveOccurred())
 		opt := metav1.ListOptions{}
 		utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 0, true, defaultTimeoutSeconds)
@@ -167,6 +164,10 @@ var _ = Describe("Compliance API recording", Ordered, Label("compliance-events-a
 		By("clean up all events")
 		_, err = kubectlManaged("delete", "events", "-n", clusterNamespace, "--all")
 		Expect(err).ShouldNot(HaveOccurred())
+
+		// Shutdown after all clean up is done in case there were some events queued up by the controllers.
+		err = server.Shutdown(ctx)
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
This helps with ordering when compliance events have a timestamp that is the same down to the second.

Relates:
https://issues.redhat.com/browse/ACM-10155