### PR TITLE
Record template-sync compliance events in compliance history API

### DIFF
--- a/controllers/statussync/policy_status_sync.go
+++ b/controllers/statussync/policy_status_sync.go
@@ -709,7 +709,10 @@ func StartComplianceEventsSyncer(
 
 		httpResponse, err := httpClient.Do(httpRequest)
 		if err != nil {
-			log.Info("Failed to record the compliance event with the compliance API. Will requeue in 10 seconds.")
+			log.Info(
+				"Failed to record the compliance event with the compliance API. Will requeue in 10 seconds.",
+				"error", err.Error(),
+			)
 
 			events.AddAfter(ceUntyped, 10*time.Second)
 			events.Done(ceUntyped)

--- a/test/resources/case23_compliance_api_recording/policy3.yaml
+++ b/test/resources/case23_compliance_api_recording/policy3.yaml
@@ -1,0 +1,45 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: case23-policy-invalid-template
+  labels:
+    policy.open-cluster-management.io/cluster-name: managed
+    policy.open-cluster-management.io/cluster-namespace: managed
+    policy.open-cluster-management.io/root-policy: case23
+  annotations:
+    policy.open-cluster-management.io/parent-policy-compliance-db-id: "2"
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: case23-policy-invalid-template
+          annotations:
+            policy.open-cluster-management.io/policy-compliance-db-id: "5"
+        spec:
+          remediationAction: inform
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Pod
+                metadata:
+                  name: nginx-pod-e2e
+                  namespace: default
+                spec:
+                  containers:
+                    - name: nginx
+          object-templates-raw: |
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Pod
+                metadata:
+                  name: nginx-pod-e2e2
+                  namespace: default
+                spec:
+                  containers:
+                    - name: nginx


### PR DESCRIPTION
The template-sync was not providing the policy template to SendEvent, so
the compliance history database ID annotations could not be added to the
Kubernetes compliance event.

This resolves the issue of not having compliance events related to a
Gatekeeper ConstraintTemplate being created successfully.