### PR TITLE
Bypass the caching of constraint templates

### DIFF
--- a/main.go
+++ b/main.go
@@ -484,6 +484,14 @@ func getManager(
 
 	options.LeaderElectionID = "governance-policy-framework-addon.open-cluster-management.io"
 	options.HealthProbeBindAddress = healthAddr
+	options.Client = client.Options{
+		Cache: &client.CacheOptions{
+			DisableFor: []client.Object{
+				&gktemplatesv1.ConstraintTemplate{},
+				&gktemplatesv1beta1.ConstraintTemplate{},
+			},
+		},
+	}
 	options.Cache = cache.Options{
 		ByObject: map[client.Object]cache.ByObject{
 			&extensionsv1.CustomResourceDefinition{}: {


### PR DESCRIPTION
Since the controller no longer restarts when the Gatekeeper installation state changes, we need to prevent controller-runtime from creating a watch on constraint templates, or else the client-go watcher will continuously log errors trying to restart the watch.

Relates:
https://github.com/open-cluster-management-io/governance-policy-framework-addon/pull/134