### PR TITLE
Handle template errors better

### DIFF
--- a/test/e2e/case10_error_test.go
+++ b/test/e2e/case10_error_test.go
@@ -96,7 +96,7 @@ var _ = Describe("Test error handling", func() {
 
 		By("Checking for event with missing name err on managed cluster in ns:" + clusterNamespace)
 		Eventually(
-			checkForEvent("case10-template-name-error", "template-error; Failed to get name from policy"),
+			checkForEvent("case10-template-name-error", "template-error; Failed to parse or get name from policy"),
 			defaultTimeoutSeconds,
 			1,
 		).Should(BeTrue())
@@ -255,7 +255,7 @@ var _ = Describe("Test error handling", func() {
 			return found
 		}, defaultTimeoutSeconds*2, 1).Should(BeFalse())
 	})
-	It("should throw a noncompliance event if a non-configurationpolicy uses a hub template", func() {
+	It("should throw a noncompliance event for hub template errors", func() {
 		By("Deploying a test policy CRD")
 		_, err := kubectlManaged("apply", "-f", yamlBasePath+"mock-crd.yaml")
 		Expect(err).ToNot(HaveOccurred())
@@ -266,11 +266,11 @@ var _ = Describe("Test error handling", func() {
 		})
 
 		hubApplyPolicy("case10-bad-hubtemplate",
-			yamlBasePath+"non-config-hubtemplate.yaml")
+			yamlBasePath+"error-hubtemplate.yaml")
 
 		By("Checking for the error event")
 		Eventually(
-			checkForEvent("case10-bad-hubtemplate", "Templates are not supported for kind"),
+			checkForEvent("case10-bad-hubtemplate", "must be aboveground"),
 			defaultTimeoutSeconds,
 			1,
 		).Should(BeTrue())

--- a/test/e2e/case22_user_validation_error_test.go
+++ b/test/e2e/case22_user_validation_error_test.go
@@ -59,15 +59,15 @@ var _ = Describe("Test proper metrics handling on syntax error", Ordered, func()
 				defaultTimeoutSeconds)
 			err := runtime.DefaultUnstructuredConverter.FromUnstructured(managedPlc.Object, &plc)
 			g.Expect(err).ToNot(HaveOccurred())
-			if len(plc.Status.Details) < 2 {
+			if len(plc.Status.Details) < 1 {
 				return ""
 			}
 
-			if len(plc.Status.Details[1].History) < 1 {
+			if len(plc.Status.Details[0].History) < 1 {
 				return ""
 			}
 
-			return plc.Status.Details[1].History[0].Message
+			return plc.Status.Details[0].History[0].Message
 		}, defaultTimeoutSeconds, 1).Should(ContainSubstring("NonCompliant; template-error;"))
 	})
 

--- a/test/resources/case10_template_sync_error_test/error-hubtemplate.yaml
+++ b/test/resources/case10_template_sync_error_test/error-hubtemplate.yaml
@@ -15,5 +15,7 @@ spec:
         kind: MockPolicy
         metadata:
           name: case10-bad-hubtemplate-policy
+          annotations:
+            policy.open-cluster-management.io/hub-templates-error: "must be aboveground"
         spec:
           foo: 'I come from {{hub the land down under hub}}'


### PR DESCRIPTION
It appears that "special" compliance events related to template-errors can potentially be superseded by later events coming from a policy controller. Specifically, if a template is valid and gets created, but is later edited to have an error, the original template is not removed. Because undesired side-effects could be caused by removing a template (eg PruneObjectBehavior in a ConfigurationPolicy), it would be risky to "fix" this by removing the template in this situation. Instead, this PR proposes that the template-sync always re-reconcile after the status is updated, which allows it to correct the "late" event by emitting a new template-error.

The increased number of reconciles does increase the possibility of duplicate compliance events. Accordingly, some tests have been relaxed, and the duplicate detection process now refreshes the policy to try and decrease the probability. It also fixes a bug that would cause a large number of duplicated events in this scheme, because the event was being recorded on the wrong item in the history.

This PR also handles hub-template errors here, instead of in individual policy controllers.

Refs:
 - https://issues.redhat.com/browse/ACM-10858