### PR TITLE
Modify equivalentTemplates for OperatorPolicy complianceConfig defaults

### DIFF
--- a/controllers/templatesync/template_sync.go
+++ b/controllers/templatesync/template_sync.go
@@ -990,6 +990,44 @@ func equivalentTemplates(eObject *unstructured.Unstructured, tObject *unstructur
 		}
 	}
 
+	if tObject.GetKind() == "OperatorPolicy" {
+		// catalogSourceUnhealthy
+		catalogSourceUnhealthy, _, _ := unstructured.NestedString(tObject.Object, "spec",
+			"complianceConfig", "catalogSourceUnhealthy")
+
+		if catalogSourceUnhealthy == "" {
+			err := unstructured.SetNestedField(tObject.Object, "Compliant", "spec",
+				"complianceConfig", "catalogSourceUnhealthy")
+			if err != nil {
+				log.Error(err, "Failed to set the default value of catalogSourceUnhealthy")
+			}
+		}
+
+		// deploymentsUnavailable
+		deploymentsUnavailable, _, _ := unstructured.NestedString(tObject.Object, "spec",
+			"complianceConfig", "deploymentsUnavailable")
+
+		if deploymentsUnavailable == "" {
+			err := unstructured.SetNestedField(tObject.Object, "NonCompliant", "spec",
+				"complianceConfig", "deploymentsUnavailable")
+			if err != nil {
+				log.Error(err, "Failed to set the default value of deploymentsUnavailable")
+			}
+		}
+
+		// upgradesAvailable
+		upgradesAvailable, _, _ := unstructured.NestedString(tObject.Object, "spec",
+			"complianceConfig", "upgradesAvailable")
+
+		if upgradesAvailable == "" {
+			err := unstructured.SetNestedField(tObject.Object, "Compliant", "spec",
+				"complianceConfig", "upgradesAvailable")
+			if err != nil {
+				log.Error(err, "Failed to set the default value of upgradesAvailable")
+			}
+		}
+	}
+
 	if !equality.Semantic.DeepEqual(eObject.UnstructuredContent()["spec"], tObject.Object["spec"]) {
 		return false
 	}

--- a/controllers/templatesync/template_sync_test.go
+++ b/controllers/templatesync/template_sync_test.go
@@ -273,3 +273,62 @@ func TestEquivalentTemplatesRecreateOption(t *testing.T) {
 		t.Fatal("Expected the templates to be equivalent")
 	}
 }
+
+func TestEquivalentTemplatesOperatorPolicyComplianceConfig(t *testing.T) {
+	existing := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "policy.open-cluster-management.io/v1beta1",
+			"kind":       "OperatorPolicy",
+			"metadata": map[string]interface{}{
+				"name": "test-policy",
+			},
+			"spec": map[string]interface{}{
+				"remediationAction": "inform",
+				"severity":          "medium",
+				"complianceType":    "musthave",
+				"subscription:": map[string]interface{}{
+					"channel":         "stable-3.10",
+					"name":            "project-quay",
+					"namespace":       "operator-policy-testns",
+					"source":          "operatorhubio-catalog",
+					"sourceNamespace": "olm",
+					"startingCSV":     "quay-operator.v3.10.0",
+				},
+				"upgradeApproval": "Automatic",
+				"complianceConfig": map[string]interface{}{
+					"catalogSourceUnhealthy": "Compliant",
+					"deploymentsUnavailable": "NonCompliant",
+					"upgradesAvailable":      "Compliant",
+				},
+			},
+		},
+	}
+
+	template := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "policy.open-cluster-management.io/v1beta1",
+			"kind":       "OperatorPolicy",
+			"metadata": map[string]interface{}{
+				"name": "test-policy",
+			},
+			"spec": map[string]interface{}{
+				"remediationAction": "inform",
+				"severity":          "medium",
+				"complianceType":    "musthave",
+				"subscription:": map[string]interface{}{
+					"channel":         "stable-3.10",
+					"name":            "project-quay",
+					"namespace":       "operator-policy-testns",
+					"source":          "operatorhubio-catalog",
+					"sourceNamespace": "olm",
+					"startingCSV":     "quay-operator.v3.10.0",
+				},
+				"upgradeApproval": "Automatic",
+			},
+		},
+	}
+
+	if !equivalentTemplates(existing, template) {
+		t.Fatal("Expected the templates to be equivalent")
+	}
+}


### PR DESCRIPTION
equivalentTemplates should correctly apply complianceConfig defaults. The complianceConfig PR: https://github.com/open-cluster-management-io/config-policy-controller/pull/252

Ref:https://issues.redhat.com/browse/ACM-11023