### PR TITLE
Detach ConstraintTemplate CRD log from a policy

### DIFF
--- a/controllers/templatesync/template_sync.go
+++ b/controllers/templatesync/template_sync.go
@@ -1135,7 +1135,7 @@ func (r *PolicyReconciler) cleanUpExcessTemplates(
 				}
 				// Log and ignore other errors to allow cleanup to continue since Gatekeeper may not be installed
 			} else if apimeta.IsNoMatchError(err) {
-				reqLogger.Info("The ConstraintTemplate CRD is not installed")
+				log.Info("The ConstraintTemplate CRD is not installed")
 				r.setCreatedGkConstraint(false)
 			} else {
 				reqLogger.Info(fmt.Sprintf("Ignoring ConstraintTemplate cleanup error: %s", err.Error()))


### PR DESCRIPTION
It doesn't make sense to have a "missing CRD" message attached to any particular reconcile. For example, the log currently appears as this, which is confusing since the policy isn't a Gatekeeper policy:
```
2024-11-26T23:57:44.964Z
info
policy-template-sync
templatesync/template_sync.go:1157
The ConstraintTemplate CRD is not installed
{"Request.Namespace": "<namespace>", "Request.Name": "<policy-namespace>.<policy-name>"}
```