### PR TITLE
Override the namespace set in the template

### DIFF
--- a/controllers/templatesync/template_sync.go
+++ b/controllers/templatesync/template_sync.go
@@ -530,6 +530,8 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 
 				overrideRemediationAction(instance, tObjectUnstructured)
 
+				tObjectUnstructured.SetNamespace(resourceNs)
+
 				eObject, err = res.Create(ctx, tObjectUnstructured, metav1.CreateOptions{})
 				if err != nil {
 					multiTemplateRegExp := regexp.MustCompile(

--- a/test/resources/case9_template_sync/case9-test-policy-with-ns.yaml
+++ b/test/resources/case9_template_sync/case9-test-policy-with-ns.yaml
@@ -1,0 +1,32 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: case9-test-policy-with-ns
+  labels:
+    policy.open-cluster-management.io/cluster-name: managed
+    policy.open-cluster-management.io/cluster-namespace: managed
+    policy.open-cluster-management.io/root-policy: case9-test-policy-with-ns
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: case9-config-policy-with-ns
+          namespace: bad
+        spec:
+          remediationAction: inform
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Pod
+                metadata:
+                  name: nginx-pod-e2e
+                  namespace: default
+                spec:
+                  containers:
+                    - name: nginx
+


### PR DESCRIPTION
Previously, if the user set a namespace in the template, then when the template-sync tried to create the template, it would fail. Now the template-sync always uses the cluster namespace, overriding what the user might have provided.

Refs:
 - https://issues.redhat.com/browse/ACM-17666