### PR TITLE
Relax equivalence on template metadata

### DIFF
--- a/controllers/templatesync/template_sync.go
+++ b/controllers/templatesync/template_sync.go
@@ -1044,19 +1044,25 @@ func equivalentTemplates(eObject *unstructured.Unstructured, tObject *unstructur
 		return false
 	}
 
-	if !equality.Semantic.DeepEqual(eObject.GetAnnotations(), tObject.GetAnnotations()) {
-		return false
+	existingAnnos := eObject.GetAnnotations()
+
+	for key, val := range tObject.GetAnnotations() {
+		existingVal, ok := existingAnnos[key]
+		if !ok || existingVal != val {
+			return false
+		}
 	}
 
-	if !equality.Semantic.DeepEqual(eObject.GetLabels(), tObject.GetLabels()) {
-		return false
+	existingLabels := eObject.GetLabels()
+
+	for key, val := range tObject.GetLabels() {
+		existingVal, ok := existingLabels[key]
+		if !ok || existingVal != val {
+			return false
+		}
 	}
 
-	if !equality.Semantic.DeepEqual(eObject.GetOwnerReferences(), tObject.GetOwnerReferences()) {
-		return false
-	}
-
-	return true
+	return equality.Semantic.DeepEqual(eObject.GetOwnerReferences(), tObject.GetOwnerReferences())
 }
 
 // setDefaultTemplateLabels ensures the template contains all necessary labels for processing

--- a/controllers/templatesync/template_sync_test.go
+++ b/controllers/templatesync/template_sync_test.go
@@ -333,6 +333,50 @@ func TestEquivalentTemplatesOperatorPolicyComplianceConfig(t *testing.T) {
 	}
 }
 
+func TestEquivalentTemplatesExtraMetadata(t *testing.T) {
+	existing := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "templates.gatekeeper.sh/v1",
+			"kind":       "ConstraintTemplate",
+			"metadata": map[string]interface{}{
+				"name": "k8srequiredlabels",
+			},
+			"spec": map[string]interface{}{
+				"crd": "fake",
+			},
+		},
+	}
+
+	existing.SetAnnotations(map[string]string{
+		"gatekeeper.sh/block-vapb-generation-until": "the-future",
+	})
+	existing.SetLabels(map[string]string{
+		"gatekeeper.sh/special": "fake",
+	})
+
+	template := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "templates.gatekeeper.sh/v1",
+			"kind":       "ConstraintTemplate",
+			"metadata": map[string]interface{}{
+				"name": "k8srequiredlabels",
+			},
+			"spec": map[string]interface{}{
+				"crd": "fake",
+			},
+		},
+	}
+
+	if !equivalentTemplates(existing, template) {
+		t.Fatal("Expected the templates to be equivalent - the existing object has extra metadata")
+	}
+
+	// Note the positions have swapped!
+	if equivalentTemplates(template, existing) {
+		t.Fatal("Expected the templates not to be equivalent - the template has extra metadata")
+	}
+}
+
 func TestGetDepNamespace(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Previously, the template and the existing resource had to have exactly matching labels and annotations. But in some cases, external controllers might add a new label or annotation, which this controller would see as a mismatch. Now it just ensures that the desired labels and annotations exist and match.

Refs:
 - https://issues.redhat.com/browse/ACM-21219