### PR TITLE
Fix restarting the gatekeeper-constraint-sync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ CONTROLLER_NAME ?= $(shell cat COMPONENT_NAME 2> /dev/null)
 ifeq ($(KIND_VERSION), minimum)
 	KIND_ARGS = --image kindest/node:v1.19.16
 	E2E_FILTER = --label-filter="!skip-minimum"
+	export DISABLE_GK_SYNC = true
 else ifneq ($(KIND_VERSION), latest)
 	KIND_ARGS = --image kindest/node:$(KIND_VERSION)
 else

--- a/controllers/gatekeepersync/gatekeeper_constraint_sync.go
+++ b/controllers/gatekeepersync/gatekeeper_constraint_sync.go
@@ -50,10 +50,15 @@ var (
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *GatekeeperConstraintReconciler) SetupWithManager(mgr ctrl.Manager, constraintEvents source.Source) error {
+	skipNameValidation := true // we need to be able to stop and restart this controller
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&policyv1.Policy{}).
 		WithEventFilter(policyPredicates()).
-		WithOptions(controller.Options{MaxConcurrentReconciles: r.ConcurrentReconciles}).
+		WithOptions(controller.Options{
+			SkipNameValidation:      &skipNameValidation,
+			MaxConcurrentReconciles: r.ConcurrentReconciles,
+		}).
 		WatchesRawSource(constraintEvents).
 		Named(ControllerName).
 		Complete(r)

--- a/main.go
+++ b/main.go
@@ -955,6 +955,11 @@ func manageGatekeeperSyncManager(
 			mgrRunning = false
 
 			mgrCtxCancel()
+
+			// Reset the context for later, otherwise the context is permanently cancelled,
+			// and the manager won't start if Gatekeeper is reinstalled.
+			//nolint:fatcontext
+			mgrCtx, mgrCtxCancel = context.WithCancel(ctx)
 		}
 
 		select {


### PR DESCRIPTION
Previously, when Gatekeeper was uninstalled, the context for the gatekeeper sync manager was permanently cancelled. As a result, if Gatekeeper was re-installed, the manager would immediately stop again, and the constraint-sync controlelr would not be started properly.

Refs:
 - https://issues.redhat.com/browse/ACM-21861