### PR TITLE
fix: check ownerRef before adding status history

### DIFF
--- a/controllers/statussync/policy_status_sync.go
+++ b/controllers/statussync/policy_status_sync.go
@@ -22,7 +22,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
 	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
@@ -284,27 +283,17 @@ func (r *PolicyReconciler) getEventsInCluster(
 // using the Policy name and nanosecond timestamp, matching the client-go
 // convention. If the template's status field is not found or is not in the
 // correct format, it returns an empty list.
-func (r *PolicyReconciler) getEventsInTemplate(
-	tmplGVK schema.GroupVersionKind, name, namespace string, policyObjID depclient.ObjectIdentifier,
-) ([]policiesv1.ComplianceHistory, error) {
-	tmplUnstruct, err := r.DynamicWatcher.Get(policyObjID, tmplGVK, namespace, name)
-	if err != nil {
-		if errors.Is(err, depclient.ErrNoVersionedResource) || errors.Is(err, depclient.ErrResourceUnwatchable) {
-			// If the kind isn't found, or isn't compatible with watches, just return an empty list.
-			return []policiesv1.ComplianceHistory{}, nil
-		}
-
-		return []policiesv1.ComplianceHistory{}, err
-	}
-
+func getEventsInTemplate(
+	tmplUnstruct *unstructured.Unstructured, policyName string,
+) []policiesv1.ComplianceHistory {
 	if tmplUnstruct == nil {
-		return []policiesv1.ComplianceHistory{}, nil
+		return []policiesv1.ComplianceHistory{}
 	}
 
 	events, found, err := unstructured.NestedSlice(tmplUnstruct.Object, "status", "history")
 	if !found || err != nil {
 		// If there's an error or the field isn't found, just return an empty list.
-		return []policiesv1.ComplianceHistory{}, nil //nolint:nilerr
+		return []policiesv1.ComplianceHistory{}
 	}
 
 	historyEvents := make([]policiesv1.ComplianceHistory, 0, len(events))
@@ -329,11 +318,36 @@ func (r *PolicyReconciler) getEventsInTemplate(
 		historyEvents = append(historyEvents, policiesv1.ComplianceHistory{
 			LastTimestamp: metav1.Time(event.LastTimestamp),
 			Message:       strings.TrimSpace(event.Message),
-			EventName:     fmt.Sprintf("%v.%x", policyObjID.Name, event.LastTimestamp.UnixNano()),
+			EventName:     fmt.Sprintf("%v.%x", policyName, event.LastTimestamp.UnixNano()),
 		})
 	}
 
-	return historyEvents, nil
+	return historyEvents
+}
+
+// templateOwnedByPolicy reports whether obj belongs to policyName.
+// A nil obj returns false.
+func templateOwnedByPolicy(obj *unstructured.Unstructured, policyName string) bool {
+	refName := ""
+
+	if obj == nil {
+		return false
+	}
+
+	for _, ownerRef := range obj.GetOwnerReferences() {
+		if ownerRef.Kind == policiesv1.Kind {
+			refName = ownerRef.Name
+
+			break
+		}
+	}
+
+	// fallback to parent policy label
+	if refName == "" {
+		refName = obj.GetLabels()[utils.ParentPolicyLabel]
+	}
+
+	return refName != "" && refName == policyName
 }
 
 // getDetails collects and processes compliance events for each policy template,
@@ -357,6 +371,8 @@ func (r *PolicyReconciler) getDetails(
 	for i, policyT := range instance.Spec.PolicyTemplates {
 		var tName string
 
+		existingDPTs := instance.Status.Details
+
 		object, tmplGVK, err := unstructured.UnstructuredJSONScheme.Decode(policyT.ObjectDefinition.Raw, nil, nil)
 		if err != nil {
 			reqLogger.Error(err, "Failed to decode policy template", "TemplateIdx", i)
@@ -371,20 +387,36 @@ func (r *PolicyReconciler) getDetails(
 			} else {
 				tName = obj.GetName()
 
-				templateEvents, err := r.getEventsInTemplate(*tmplGVK, tName, instance.Namespace, policyObjID)
+				tmplUnstruct, err := r.DynamicWatcher.Get(policyObjID, *tmplGVK, instance.Namespace, tName)
 				if err != nil {
-					reqLogger.Error(err, "Error getting template, will requeue the request",
-						"TemplateName", tName, "TemplateIdx", i)
+					// Kind not found, or not compatible with watches
+					shouldReturnErr := !errors.Is(err, depclient.ErrNoVersionedResource) &&
+						!errors.Is(err, depclient.ErrResourceUnwatchable)
 
-					return nil, err
+					if shouldReturnErr {
+						reqLogger.Error(err, "Error getting template, will requeue the request",
+							"TemplateName", tName, "TemplateIdx", i)
+
+						return nil, err
+					}
 				}
 
-				eventForPolicyMap[tName] = append(eventForPolicyMap[tName], templateEvents...)
+				tmplOwnedByPolicy := templateOwnedByPolicy(tmplUnstruct, policyObjID.Name)
+
+				if tmplOwnedByPolicy {
+					templateEvents := getEventsInTemplate(tmplUnstruct, policyObjID.Name)
+					eventForPolicyMap[tName] = append(eventForPolicyMap[tName], templateEvents...)
+				}
+
+				if tmplUnstruct != nil && !tmplOwnedByPolicy {
+					// If the template exists AND belongs to another policy, skip this DPT.
+					existingDPTs = nil
+				}
 			}
 		}
 
 		detailLogger := reqLogger.WithValues("TemplateName", tName, "TemplateIdx", i)
-		templateDetails := mergeDetails(eventForPolicyMap[tName], instance.Status.Details, tName, detailLogger)
+		templateDetails := mergeDetails(eventForPolicyMap[tName], existingDPTs, tName, detailLogger)
 
 		allDetails = append(allDetails, templateDetails)
 

--- a/controllers/statussync/policy_status_sync_test.go
+++ b/controllers/statussync/policy_status_sync_test.go
@@ -3,6 +3,14 @@ package statussync
 
 import (
 	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+
+	"open-cluster-management.io/governance-policy-framework-addon/controllers/utils"
 )
 
 func TestParseTimestampFromEventName(t *testing.T) {
@@ -16,5 +24,179 @@ func TestParseTimestampFromEventName(t *testing.T) {
 	output, err = parseTimestampFromEventName("event.with-no-timestamp")
 	if err == nil {
 		t.Errorf("Expected an error but got none: %s", output)
+	}
+}
+
+func TestTemplateOwnedByPolicy(t *testing.T) {
+	t.Parallel()
+
+	ctrl := true
+	polRef := func(name string) metav1.OwnerReference {
+		return metav1.OwnerReference{
+			APIVersion: policiesv1.GroupVersion.String(),
+			Kind:       policiesv1.Kind,
+			Name:       name,
+			Controller: &ctrl,
+		}
+	}
+	buildTmpl := func(owner, parentLabel string, otherOwners ...string) *unstructured.Unstructured {
+		tmpl := &unstructured.Unstructured{}
+
+		var refs []metav1.OwnerReference
+		if owner != "" {
+			refs = append(refs, polRef(owner))
+		}
+
+		for _, name := range otherOwners {
+			refs = append(refs, polRef(name))
+		}
+
+		if len(refs) > 0 {
+			tmpl.SetOwnerReferences(refs)
+		}
+
+		if parentLabel != "" {
+			tmpl.SetLabels(map[string]string{utils.ParentPolicyLabel: parentLabel})
+		}
+
+		return tmpl
+	}
+
+	tests := []struct {
+		name   string
+		policy string
+		tmpl   *unstructured.Unstructured
+		want   bool
+	}{
+		{
+			name:   "Nil template returns false",
+			policy: "policy-a",
+			tmpl:   nil,
+			want:   false,
+		},
+		{
+			name:   "Empty template with no ownership metadata returns false",
+			policy: "policy-a",
+			tmpl:   &unstructured.Unstructured{},
+			want:   false,
+		},
+		{
+			name:   "Policy owner reference matches policy",
+			policy: "policy-a",
+			tmpl:   buildTmpl("policy-a", ""),
+			want:   true,
+		},
+		{
+			name:   "Policy owner reference does not match policy",
+			policy: "policy-b",
+			tmpl:   buildTmpl("policy-a", ""),
+			want:   false,
+		},
+		{
+			name:   "Parent policy label matches when owner reference is absent",
+			policy: "policy-a",
+			tmpl:   buildTmpl("", "policy-a"),
+			want:   true,
+		},
+		{
+			name:   "Parent policy label does not match when owner reference is absent",
+			policy: "policy-b",
+			tmpl:   buildTmpl("", "policy-a"),
+			want:   false,
+		},
+		{
+			name:   "Owner reference takes precedence over parent policy label",
+			policy: "policy-b",
+			tmpl:   buildTmpl("policy-a", "policy-b"),
+			want:   false,
+		},
+		{
+			name:   "First policy owner reference is used when multiple are present",
+			policy: "policy-a",
+			tmpl:   buildTmpl("policy-a", "", "policy-b"),
+			want:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := templateOwnedByPolicy(tt.tmpl, tt.policy); got != tt.want {
+				t.Errorf("templateOwnedByPolicy() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetEventsInTemplate(t *testing.T) {
+	t.Parallel()
+
+	controller := true
+	tmplGVK := schema.GroupVersionKind{
+		Group:   "policy.open-cluster-management.io",
+		Version: "v1",
+		Kind:    "ConfigurationPolicy",
+	}
+	historyTime := metav1.NewTime(time.Date(2024, 12, 23, 17, 1, 23, 456789000, time.UTC))
+	historyMsg := "Compliant; history message for policy-a"
+
+	makeTestTmpl := func() *unstructured.Unstructured {
+		tmpl := &unstructured.Unstructured{}
+		tmpl.SetGroupVersionKind(tmplGVK)
+		tmpl.SetOwnerReferences([]metav1.OwnerReference{{
+			APIVersion: "policy.open-cluster-management.io/v1",
+			Kind:       policiesv1.Kind,
+			Name:       "policy-a",
+			Controller: &controller,
+		}})
+		tmpl.SetLabels(map[string]string{utils.ParentPolicyLabel: "policy-a"})
+
+		err := unstructured.SetNestedSlice(tmpl.Object, []any{
+			map[string]any{
+				"lastTimestamp": historyTime.Format(time.RFC3339Nano),
+				"message":       historyMsg,
+			},
+		}, "status", "history")
+		if err != nil {
+			t.Fatalf("failed to set template history: %v", err)
+		}
+
+		return tmpl
+	}
+
+	tests := []struct {
+		name       string
+		template   *unstructured.Unstructured
+		policyName string
+		wantLen    int
+	}{
+		{
+			name:       "returns history from template status",
+			template:   makeTestTmpl(),
+			policyName: "policy-a",
+			wantLen:    1,
+		},
+		{
+			name:       "returns empty list when template is missing",
+			policyName: "policy-a",
+			wantLen:    0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			events := getEventsInTemplate(tt.template, tt.policyName)
+
+			if len(events) != tt.wantLen {
+				t.Fatalf("getEventsInTemplate() len = %d, want %d", len(events), tt.wantLen)
+			}
+
+			if tt.wantLen == 1 && events[0].Message != historyMsg {
+				t.Errorf("getEventsInTemplate() message = %q, want %q", events[0].Message, historyMsg)
+			}
+		})
 	}
 }

--- a/test/e2e/case10_error_test.go
+++ b/test/e2e/case10_error_test.go
@@ -170,22 +170,84 @@ var _ = Describe("Test error handling", func() {
 		).Should(BeTrue())
 	})
 	It("should generate duplicate policy template err event", func(ctx SpecContext) {
+		const (
+			duplicatePolicyName = "case10-test-policy-duplicate"
+			configPolicyName    = "case10-config-policy"
+			foreignHistoryMsg   = "Compliant; history message for case10-test-policy"
+		)
+
 		hubApplyPolicy("case10-test-policy",
 			yamlBasePath+"working-policy.yaml")
 
 		// wait for original policy to be processed before creating duplicate policy
 		utils.GetWithTimeout(clientManagedDynamic, gvrConfigurationPolicy,
-			"case10-config-policy", clusterNamespace, true, defaultTimeoutSeconds)
+			configPolicyName, clusterNamespace, true, defaultTimeoutSeconds)
 
-		hubApplyPolicy("case10-test-policy-duplicate",
+		By("Adding compliance history to the existing configuration policy")
+		historyPatch := `{"status": {"history": [{"lastTimestamp": "2024-12-23T17:01:23.456789Z", "message": "` +
+			foreignHistoryMsg + `"}]}}`
+		_, err := kubectlManaged("patch", "configurationpolicy", configPolicyName, "-n="+clusterNamespace,
+			"--type=merge", "--subresource=status", "-p="+historyPatch)
+		Expect(err).ToNot(HaveOccurred())
+
+		hubApplyPolicy(duplicatePolicyName,
 			yamlBasePath+"working-policy-duplicate.yaml")
 
 		By("Checking for event with duplicate err on managed cluster in ns:" + clusterNamespace)
 		Eventually(
-			checkForEvent(ctx, "case10-test-policy-duplicate", "Template name must be unique"),
+			checkForEvent(ctx, duplicatePolicyName, "Template name must be unique"),
 			defaultTimeoutSeconds,
 			1,
 		).Should(BeTrue())
+
+		By("Checking duplicate policy status does not contain foreign template history")
+		Eventually(func(g Gomega) {
+			managedPlc := utils.GetWithTimeout(
+				clientManagedDynamic,
+				gvrPolicy,
+				duplicatePolicyName,
+				clusterNamespace,
+				true,
+				defaultTimeoutSeconds)
+
+			var plc *policiesv1.Policy
+			err := runtime.DefaultUnstructuredConverter.FromUnstructured(managedPlc.Object, &plc)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(plc.Status.Details).To(HaveLen(1))
+			g.Expect(plc.Status.Details[0].History).ToNot(BeEmpty())
+
+			for _, hist := range plc.Status.Details[0].History {
+				g.Expect(hist.Message).ToNot(ContainSubstring(foreignHistoryMsg))
+			}
+		}, defaultTimeoutSeconds, 1).Should(Succeed())
+
+		By("Checking stale leaked history is removed after duplicate template conflict is detected")
+		leakedHistoryPatch := `[{"op":"add","path":"/status/details/0/history/-","value":{` +
+			`"eventName":"` + duplicatePolicyName + `.18ad64b95843ed60",` +
+			`"lastTimestamp":"2026-05-07T21:09:35Z",` +
+			`"message":"` + foreignHistoryMsg + `"}}]`
+		policyInt := clientManagedDynamic.Resource(gvrPolicy).Namespace(clusterNamespace)
+		_, err = policyInt.Patch(ctx, duplicatePolicyName, types.JSONPatchType,
+			[]byte(leakedHistoryPatch), metav1.PatchOptions{}, "status")
+		Expect(err).ToNot(HaveOccurred())
+
+		Eventually(func(g Gomega) {
+			managedPlc := utils.GetWithTimeout(
+				clientManagedDynamic,
+				gvrPolicy,
+				duplicatePolicyName,
+				clusterNamespace,
+				true,
+				defaultTimeoutSeconds)
+
+			var plc *policiesv1.Policy
+			err := runtime.DefaultUnstructuredConverter.FromUnstructured(managedPlc.Object, &plc)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			for _, hist := range plc.Status.Details[0].History {
+				g.Expect(hist.Message).ToNot(ContainSubstring(foreignHistoryMsg))
+			}
+		}, defaultTimeoutSeconds, 1).Should(Succeed())
 	})
 	It("should create other objects, even when one is invalid", func(ctx SpecContext) {
 		hubApplyPolicy("case10-middle-tmpl",


### PR DESCRIPTION
ref: https://redhat.atlassian.net/browse/ACM-34512

When two policy templates share the same name, validate the template belongs to the Policy before appending its history to the Policy

Depends on https://github.com/open-cluster-management-io/governance-policy-framework-addon/pull/229

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved policy template history tracking to prevent events from unrelated policies from appearing in managed policy status.
  * Correctly handles missing or unavailable templates during status synchronization.
  * Ensures stale foreign history is removed during subsequent reconciliations.

* **Tests**
  * Added coverage for template ownership detection and compliance-history extraction.
  * Expanded end-to-end validation for duplicate templates and isolated status history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->