### PR TITLE
chore: clean up unused env

### DIFF
--- a/deploy/manager/manager.yaml
+++ b/deploy/manager/manager.yaml
@@ -34,12 +34,6 @@ spec:
             - name: klusterlet-config
               mountPath: /var/run/klusterlet
           env:
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: OPERATOR_NAME
-              value: governance-policy-framework-addon
             - name: DEPLOYMENT_NAME
               valueFrom:
                 fieldRef:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -210,12 +210,6 @@ spec:
         command:
         - governance-policy-framework-addon
         env:
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        - name: OPERATOR_NAME
-          value: governance-policy-framework-addon
         - name: DEPLOYMENT_NAME
           valueFrom:
             fieldRef:


### PR DESCRIPTION
It appears OPERATOR_NAME and POD_NAME are no longer in use.