### PR TITLE
chore: add `events.k8s.io` to leader election

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -24,6 +24,7 @@ rules:
   - delete
 - apiGroups:
   - ""
+  - events.k8s.io
   resources:
   - events
   verbs:

--- a/deploy/rbac/leader_election_role.yaml
+++ b/deploy/rbac/leader_election_role.yaml
@@ -18,6 +18,7 @@ rules:
   - delete
 - apiGroups:
   - ""
+  - events.k8s.io
   resources:
   - events
   verbs:


### PR DESCRIPTION
For consistency (since it already has event permissions anyway), and also to align with changes made in the addon-controller.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded Kubernetes permissions for event handling so the app can create and update events from both supported event API groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->