### PR TITLE
Add TLS Profile compliance

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -83,6 +83,11 @@ jobs:
         make build-images
         KUBECONFIG=${PWD}/kubeconfig_managed_e2e make kind-deploy-controller-dev
 
+    - name: E2E tests that require the controller running in a cluster
+      run: |
+        export GOPATH=$(go env GOPATH)
+        KUBECONFIG=${PWD}/kubeconfig_managed_e2e make e2e-test-running-in-cluster
+
     - name: Run E2E Uninstallation Tests
       if: ${{ matrix.kind == 'latest' }}
       run: |

--- a/Makefile
+++ b/Makefile
@@ -46,12 +46,14 @@ CONTROLLER_NAME ?= $(shell cat COMPONENT_NAME 2> /dev/null)
 # Set the Kind version tag
 ifeq ($(KIND_VERSION), minimum)
 	KIND_ARGS = --image kindest/node:v1.19.16
-	E2E_FILTER = --label-filter="!skip-minimum"
+	E2E_FILTER = --label-filter="!skip-minimum && !running-in-cluster"
 	export DISABLE_GK_SYNC = true
 else ifneq ($(KIND_VERSION), latest)
 	KIND_ARGS = --image kindest/node:$(KIND_VERSION)
+	E2E_FILTER = --label-filter="!running-in-cluster"
 else
 	KIND_ARGS =
+	E2E_FILTER = --label-filter="!running-in-cluster"
 endif
 # Test coverage threshold
 export COVERAGE_MIN ?= 69
@@ -96,7 +98,7 @@ lint:
 # test section
 ############################################################
 
-TEST_PKGS ?= ./controllers/statussync ./controllers/secretsync ./controllers/templatesync ./controllers/utils
+TEST_PKGS ?= . ./controllers/statussync ./controllers/secretsync ./controllers/templatesync ./controllers/utils
 
 .PHONY: test
 test: envtest kubebuilder gotestsum
@@ -259,6 +261,12 @@ e2e-test-hosted-coverage: COVERAGE_E2E_OUT = coverage_e2e_hosted_mode.out
 e2e-test-hosted-coverage: E2E_JSON = --json-report=report_e2e_hosted.json
 e2e-test-hosted-coverage: E2E_JUNIT = --junit-report=report_e2e_hosted.xml
 e2e-test-hosted-coverage: e2e-run-instrumented e2e-test e2e-stop-instrumented
+
+.PHONY: e2e-test-running-in-cluster
+e2e-test-running-in-cluster: E2E_FILTER = --label-filter="running-in-cluster"
+e2e-test-running-in-cluster: E2E_JSON = --json-report=report_e2e_running_in_cluster.json
+e2e-test-running-in-cluster: E2E_JUNIT = --junit-report=report_e2e_running_in_cluster.xml
+e2e-test-running-in-cluster: e2e-test
 
 .PHONY: scale-down-deployment
 scale-down-deployment:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -38,6 +38,16 @@ metadata:
 rules:
 - apiGroups:
   - ""
+  resourceNames:
+  - ocm-tls-profile
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
   resources:
   - pods
   verbs:

--- a/deploy/rbac/role.yaml
+++ b/deploy/rbac/role.yaml
@@ -6,6 +6,16 @@ metadata:
 rules:
 - apiGroups:
   - ""
+  resourceNames:
+  - ocm-tls-profile
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
   resources:
   - pods
   verbs:

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	open-cluster-management.io/addon-framework v1.3.0
 	open-cluster-management.io/config-policy-controller v0.19.1-0.20260713183034-154ac0b4da4a
 	open-cluster-management.io/governance-policy-propagator v0.19.0
+	open-cluster-management.io/sdk-go v1.3.0
 	sigs.k8s.io/controller-runtime v0.23.3
 )
 

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"flag"
 	"fmt"
@@ -45,6 +46,7 @@ import (
 	"k8s.io/klog/v2"
 	"open-cluster-management.io/addon-framework/pkg/lease"
 	addonutils "open-cluster-management.io/addon-framework/pkg/utils"
+	sdktls "open-cluster-management.io/sdk-go/pkg/tls"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -155,6 +157,10 @@ func main() {
 	managedCfg.QPS = tool.Options.ClientQPS
 	managedCfg.Burst = int(tool.Options.ClientBurst)
 
+	mainCtx := ctrl.SetupSignalHandler()
+
+	tlsCfg := resolveEffectiveTLSConfig(mainCtx, managedCfg)
+
 	metricsOptions := server.Options{
 		BindAddress: tool.Options.MetricsAddr,
 	}
@@ -163,6 +169,7 @@ func main() {
 		metricsOptions.FilterProvider = filters.WithAuthenticationAndAuthorization
 		metricsOptions.SecureServing = true
 		metricsOptions.CertDir = "/var/run/metrics-cert"
+		metricsOptions.TLSOpts = []func(*tls.Config){sdktls.ConfigToFunc(tlsCfg)}
 	}
 
 	mgrOptionsBase := manager.Options{
@@ -235,7 +242,6 @@ func main() {
 	healthAddressesLock.Lock()
 
 	healthAddresses[mgrHealthAddr] = true
-	mainCtx := ctrl.SetupSignalHandler()
 	mgrCtx, mgrCtxCancel := context.WithCancel(mainCtx)
 
 	mgr := getManager(mgrCtx, mgrOptionsBase, mgrHealthAddr, hubCfg, managedCfg)

--- a/test/e2e/case23_tls_profile_test.go
+++ b/test/e2e/case23_tls_profile_test.go
@@ -1,0 +1,134 @@
+// Copyright (c) 2026 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package e2e
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	sdktls "open-cluster-management.io/sdk-go/pkg/tls"
+)
+
+const (
+	controllerNamespace = "open-cluster-management-agent-addon"
+	containerName       = "governance-policy-framework-addon"
+	podLabelSelector    = "name=governance-policy-framework-addon"
+)
+
+// This test only works when the controller is running as a real Deployment-managed pod in the
+// cluster: it verifies that the ocm-tls-profile ConfigMap watcher exits the process on change,
+// which relies on the kubelet restarting the container. Running it against the locally-run
+// instrumented binary used by `make e2e-test-coverage` would just kill that process and take down
+// the rest of the suite, so it is excluded from that target via the "running-in-cluster" label
+// (see e2e-test-running-in-cluster in the Makefile).
+var _ = Describe("TLS profile ConfigMap", Label("running-in-cluster"), Serial, func() {
+	var podName string
+
+	BeforeEach(func(ctx context.Context) {
+		pods, err := clientManaged.CoreV1().Pods(controllerNamespace).List(ctx, metav1.ListOptions{
+			LabelSelector: podLabelSelector,
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		if len(pods.Items) == 0 {
+			Skip("governance-policy-framework-addon is not running as a pod in the cluster")
+		}
+
+		podName = pods.Items[0].Name
+	})
+
+	AfterEach(func(ctx context.Context) {
+		if podName == "" {
+			return
+		}
+
+		initialRestarts := getContainerRestartCount(ctx, podName)
+
+		err := clientManaged.CoreV1().ConfigMaps(controllerNamespace).Delete(
+			ctx, sdktls.ConfigMapName, metav1.DeleteOptions{},
+		)
+		if k8serrors.IsNotFound(err) {
+			return
+		}
+
+		Expect(err).ToNot(HaveOccurred())
+
+		// Deleting the ConfigMap is itself a change the watcher reacts to (the effective TLS
+		// config falls back to a TLS 1.2 floor with Go's default cipher suites), so it also
+		// restarts the container. Wait for that to settle here, otherwise a subsequent
+		// "running-in-cluster" spec could start against a pod that's still restarting from this
+		// cleanup.
+		By("Waiting for the controller container to restart again after removing the ocm-tls-profile ConfigMap")
+		Eventually(func() int {
+			return getContainerRestartCount(ctx, podName)
+		}, defaultTimeoutSeconds, 1).Should(BeNumerically(">", initialRestarts))
+
+		By("Waiting for the pod to become ready again")
+		waitForPodReady(ctx, podName)
+	})
+
+	It("restarts the controller container when the ocm-tls-profile ConfigMap changes", func(ctx context.Context) {
+		initialRestarts := getContainerRestartCount(ctx, podName)
+
+		By("Creating the ocm-tls-profile ConfigMap")
+
+		_, err := clientManaged.CoreV1().ConfigMaps(controllerNamespace).Create(
+			ctx, &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      sdktls.ConfigMapName,
+					Namespace: controllerNamespace,
+				},
+				Data: map[string]string{
+					sdktls.ConfigMapKeyMinVersion: "VersionTLS13",
+				},
+			}, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verifying the controller container restarts to pick up the new TLS settings")
+		Eventually(func() int {
+			return getContainerRestartCount(ctx, podName)
+		}, defaultTimeoutSeconds, 1).Should(BeNumerically(">", initialRestarts))
+
+		By("Waiting for the pod to become ready again")
+		waitForPodReady(ctx, podName)
+	})
+})
+
+func getContainerRestartCount(ctx context.Context, podName string) int {
+	pod, err := clientManaged.CoreV1().Pods(controllerNamespace).Get(
+		ctx, podName, metav1.GetOptions{},
+	)
+	Expect(err).ToNot(HaveOccurred())
+
+	for _, cs := range pod.Status.ContainerStatuses {
+		if cs.Name == containerName {
+			return int(cs.RestartCount)
+		}
+	}
+
+	return -1
+}
+
+func waitForPodReady(ctx context.Context, podName string) {
+	Eventually(func() (bool, error) {
+		pod, err := clientManaged.CoreV1().Pods(controllerNamespace).Get(
+			ctx, podName, metav1.GetOptions{},
+		)
+		if err != nil {
+			return false, err
+		}
+
+		for _, cond := range pod.Status.Conditions {
+			if cond.Type == corev1.PodReady {
+				return cond.Status == corev1.ConditionTrue, nil
+			}
+		}
+
+		return false, nil
+	}, defaultTimeoutSeconds, 1).Should(BeTrue())
+}

--- a/tlsconfig.go
+++ b/tlsconfig.go
@@ -1,0 +1,151 @@
+// Copyright (c) 2026 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	authorizationv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	sdktls "open-cluster-management.io/sdk-go/pkg/tls"
+
+	"open-cluster-management.io/governance-policy-framework-addon/tool"
+)
+
+// resolveEffectiveTLSConfig wires resolveTLSConfig into the running process: it discovers the
+// addon's own namespace (to watch the ocm-tls-profile ConfigMap on the managed cluster), restarts
+// the process on ConfigMap changes, and logs the config that will be applied. If no flags or
+// ConfigMap settings apply, it falls back to Go's default cipher suites with an explicit TLS 1.2
+// floor.
+func resolveEffectiveTLSConfig(ctx context.Context, managedCfg *rest.Config) *sdktls.TLSConfig {
+	operatorNamespace, err := tool.GetOperatorNamespace()
+	if err != nil {
+		if errors.Is(err, tool.ErrNoNamespace) || errors.Is(err, tool.ErrRunLocal) {
+			log.Info("Not running in a cluster; skipping the ocm-tls-profile ConfigMap watch")
+		} else {
+			log.Error(err, "Failed to get operator namespace; skipping the ocm-tls-profile ConfigMap watch")
+		}
+
+		operatorNamespace = ""
+	}
+
+	var kubeClient kubernetes.Interface
+	if operatorNamespace != "" {
+		kubeClient = kubernetes.NewForConfigOrDie(managedCfg)
+	}
+
+	tlsCfg, err := resolveTLSConfig(
+		ctx, tool.Options.TLSMinVersion, tool.Options.TLSCipherSuites, kubeClient, operatorNamespace,
+		func() {
+			log.Info("TLS configuration changed; exiting so the pod restarts with the new settings")
+			os.Exit(0)
+		},
+	)
+	if err != nil {
+		log.Error(err, "Failed to resolve TLS configuration; falling back to defaults")
+
+		tlsCfg = nil
+	}
+
+	effective := tlsCfg
+	if effective == nil {
+		effective = sdktls.GetDefaultTLSConfig()
+	}
+
+	log.Info("Effective TLS configuration",
+		"minVersion", sdktls.VersionToString(effective.MinVersion),
+		"cipherSuites", sdktls.CipherSuitesToString(effective.CipherSuites),
+	)
+
+	return effective
+}
+
+// The ConfigMap watcher below needs get/list/watch on the ocm-tls-profile ConfigMap in the
+// addon's own namespace. sdktls.StartTLSConfigMapWatcher lists/watches with a metadata.name field
+// selector matching ConfigMapName, which is what lets list/watch be scoped by resourceNames here
+// (see the secretsync package's identical pattern for policy-encryption-key).
+//+kubebuilder:rbac:groups=core,resources=configmaps,resourceNames=ocm-tls-profile,verbs=get;list;watch
+
+// resolveTLSConfig determines the TLS configuration to apply to the metrics server, in order of
+// precedence:
+//  1. Explicit --tls-min-version/--tls-cipher-suites flags.
+//  2. The ocm-tls-profile ConfigMap in the addon's own namespace, if kubeClient and namespace are
+//     available and RBAC permits list/watch on it. This also starts a background watcher that
+//     invokes onConfigMapChange when the ConfigMap's data changes. If the ConfigMap doesn't exist
+//     yet, sdktls.StartTLSConfigMapWatcher still returns a non-nil TLSConfig (Go's TLS 1.2
+//     defaults) rather than nil, since it needs something concrete to seed the watcher's change
+//     detection. If RBAC denies list/watch, returns an error instead of starting the watcher so
+//     the caller falls back to defaults - see canWatchTLSProfileConfigMap for more details.
+//  3. If kubeClient or namespace is unavailable (e.g. not running in a cluster), returns
+//     (nil, nil) so the caller falls back to a TLS 1.2 floor with Go's default cipher suites.
+func resolveTLSConfig(
+	ctx context.Context, minVersion, cipherSuites string, kubeClient kubernetes.Interface, namespace string,
+	onConfigMapChange func(),
+) (*sdktls.TLSConfig, error) {
+	flagCfg, err := sdktls.ConfigFromFlags(minVersion, cipherSuites)
+	if err != nil {
+		return nil, err
+	}
+
+	if flagCfg != nil {
+		return flagCfg, nil
+	}
+
+	if kubeClient == nil || namespace == "" {
+		return nil, nil
+	}
+
+	allowed, err := canWatchTLSProfileConfigMap(ctx, kubeClient, namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	if !allowed {
+		return nil, fmt.Errorf(
+			"missing permission to list/watch the %s ConfigMap in namespace %s", sdktls.ConfigMapName, namespace,
+		)
+	}
+
+	return sdktls.StartTLSConfigMapWatcher(ctx, kubeClient, namespace, onConfigMapChange)
+}
+
+// canWatchTLSProfileConfigMap checks list/watch access to the ocm-tls-profile ConfigMap via
+// SelfSubjectAccessReview, which needs no RBAC of its own, instead of finding out the hard way
+// from sdktls.StartTLSConfigMapWatcher (which hangs rather than erroring on missing RBAC).
+func canWatchTLSProfileConfigMap(ctx context.Context, kubeClient kubernetes.Interface, namespace string) (bool, error) {
+	for _, verb := range []string{"list", "watch"} {
+		review := &authorizationv1.SelfSubjectAccessReview{
+			Spec: authorizationv1.SelfSubjectAccessReviewSpec{
+				ResourceAttributes: &authorizationv1.ResourceAttributes{
+					Namespace: namespace,
+					Verb:      verb,
+					Resource:  "configmaps",
+					Name:      sdktls.ConfigMapName,
+				},
+			},
+		}
+
+		reviewCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
+
+		result, err := kubeClient.AuthorizationV1().SelfSubjectAccessReviews().Create(
+			reviewCtx, review, metav1.CreateOptions{})
+		if err != nil {
+			return false, fmt.Errorf("failed to check %s permission on the %s ConfigMap: %w",
+				verb, sdktls.ConfigMapName, err)
+		}
+
+		if !result.Status.Allowed {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}

--- a/tlsconfig_test.go
+++ b/tlsconfig_test.go
@@ -1,0 +1,150 @@
+// Copyright (c) 2026 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package main
+
+import (
+	"testing"
+
+	authorizationv1 "k8s.io/api/authorization/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	testclient "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+	sdktls "open-cluster-management.io/sdk-go/pkg/tls"
+)
+
+// allowSelfSubjectAccessReviews makes a fake clientset report every SelfSubjectAccessReview as
+// allowed. Without this, the fake client's default "create" reaction just stores and echoes back
+// the submitted object, leaving Status.Allowed at its false zero value - indistinguishable from a
+// real permission denial.
+func allowSelfSubjectAccessReviews(client *testclient.Clientset) {
+	client.PrependReactor("create", "selfsubjectaccessreviews",
+		func(action k8stesting.Action) (bool, runtime.Object, error) {
+			//nolint:forcetypeassert
+			review := action.(k8stesting.CreateAction).GetObject().(*authorizationv1.SelfSubjectAccessReview)
+			review.Status.Allowed = true
+
+			return true, review, nil
+		},
+	)
+}
+
+func TestResolveTLSConfigFlagsTakePrecedence(t *testing.T) {
+	t.Parallel()
+
+	wantVersion, err := sdktls.ParseTLSVersion("VersionTLS13")
+	if err != nil {
+		t.Fatalf("failed to parse the expected TLS version: %v", err)
+	}
+
+	// A nil kubeClient would panic if resolveTLSConfig tried to use it, proving the ConfigMap
+	// path is skipped when the flags are set.
+	cfg, err := resolveTLSConfig(t.Context(), "VersionTLS13", "", nil, "", func() {})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg == nil {
+		t.Fatal("expected a non-nil TLS config")
+	}
+
+	if cfg.MinVersion != wantVersion {
+		t.Errorf("got MinVersion %d, want %d", cfg.MinVersion, wantVersion)
+	}
+}
+
+func TestResolveTLSConfigInvalidFlagsReturnsError(t *testing.T) {
+	t.Parallel()
+
+	_, err := resolveTLSConfig(t.Context(), "not-a-version", "", nil, "", func() {})
+	if err == nil {
+		t.Fatal("expected an error for an invalid TLS version flag")
+	}
+}
+
+func TestResolveTLSConfigNoFlagsNoClusterFallsBackToNil(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := resolveTLSConfig(t.Context(), "", "", nil, "", func() {})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg != nil {
+		t.Errorf("expected a nil config so the caller falls back to defaults, got %+v", cfg)
+	}
+}
+
+func TestResolveTLSConfigReadsConfigMapWhenNoFlags(t *testing.T) {
+	t.Parallel()
+
+	client := testclient.NewSimpleClientset(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      sdktls.ConfigMapName,
+			Namespace: "addon-ns",
+		},
+		Data: map[string]string{
+			sdktls.ConfigMapKeyMinVersion: "VersionTLS13",
+		},
+	})
+	allowSelfSubjectAccessReviews(client)
+
+	cfg, err := resolveTLSConfig(t.Context(), "", "", client, "addon-ns", func() {})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg == nil {
+		t.Fatal("expected a non-nil TLS config")
+	}
+
+	wantVersion, err := sdktls.ParseTLSVersion("VersionTLS13")
+	if err != nil {
+		t.Fatalf("failed to parse the expected TLS version: %v", err)
+	}
+
+	if cfg.MinVersion != wantVersion {
+		t.Errorf("got MinVersion %d, want %d", cfg.MinVersion, wantVersion)
+	}
+}
+
+func TestResolveTLSConfigDefaultsWhenConfigMapAbsent(t *testing.T) {
+	t.Parallel()
+
+	client := testclient.NewSimpleClientset()
+	allowSelfSubjectAccessReviews(client)
+
+	cfg, err := resolveTLSConfig(t.Context(), "", "", client, "addon-ns", func() {})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg == nil {
+		t.Fatal("expected a non-nil TLS config seeded with Go's TLS 1.2 defaults")
+	}
+
+	wantDefault := sdktls.GetDefaultTLSConfig()
+	if cfg.MinVersion != wantDefault.MinVersion {
+		t.Errorf("got MinVersion %d, want %d", cfg.MinVersion, wantDefault.MinVersion)
+	}
+}
+
+func TestResolveTLSConfigMissingConfigMapPermissionReturnsError(t *testing.T) {
+	t.Parallel()
+
+	// No allowSelfSubjectAccessReviews call: the fake client's default reaction leaves
+	// Status.Allowed at its false zero value, simulating denied RBAC.
+	client := testclient.NewSimpleClientset(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      sdktls.ConfigMapName,
+			Namespace: "addon-ns",
+		},
+	})
+
+	_, err := resolveTLSConfig(t.Context(), "", "", client, "addon-ns", func() {})
+	if err == nil {
+		t.Fatal("expected an error when list/watch permission on the ConfigMap is denied")
+	}
+}

--- a/tool/options.go
+++ b/tool/options.go
@@ -33,6 +33,8 @@ type SyncerOptions struct {
 	EvaluationConcurrency uint8
 	ClientQPS             float32
 	ClientBurst           uint32
+	TLSMinVersion         string
+	TLSCipherSuites       string
 }
 
 var disableSpecSync bool
@@ -152,6 +154,22 @@ func ProcessFlags() {
 		45, // the controller-runtime defaults are 20:30 (qps:burst) - this matches that ratio
 		"The maximum burst before client requests will be throttled. "+
 			"Will scale with concurrency, if not explicitly set.",
+	)
+
+	flag.StringVar(
+		&Options.TLSMinVersion,
+		"tls-min-version",
+		"",
+		"The minimum TLS version to use on the metrics server (e.g. VersionTLS12). "+
+			"Overrides the ocm-tls-profile ConfigMap when set.",
+	)
+
+	flag.StringVar(
+		&Options.TLSCipherSuites,
+		"tls-cipher-suites",
+		"",
+		"A comma-separated list of IANA cipher suite names to use on the metrics server. "+
+			"Overrides the ocm-tls-profile ConfigMap when set.",
 	)
 }
 


### PR DESCRIPTION
The addon-framework will deploy an ocm-tls-profile ConfigMap to the namespace, providing guidance on what settings to use. New `--tls-*` flags can be used to override that behavior. When neither are present, Go's default cipher suites will be used, with a minimum of TLS 1.2.

A new background watcher restarts the container when the new ConfigMap changes, to ensure the new settings take effect.

Refs:
 - https://issues.redhat.com/browse/ACM-30176

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable TLS settings for secure metrics, including minimum TLS version and cipher suites.
  * TLS settings can be provided through command-line options or the managed cluster configuration.
  * The controller restarts automatically when the TLS profile changes and becomes ready with the updated settings.
  * Added safe defaults when no TLS profile is configured.
  * Added the required permissions to read the TLS profile configuration.

* **Tests**
  * Added unit and in-cluster end-to-end coverage for TLS configuration and profile updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->